### PR TITLE
fix(ci): run PR workflow with pull_request trigger

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,42 +1,85 @@
 name: PR Checks and Build
 
 on:
-  pull_request_target:
-    types: [opened, synchronize]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# The jobs that build and test run branch-controlled code, so the default grant
+# is read-only and the two jobs that need to write ask for it themselves.
 permissions:
   contents: read
-  pull-requests: write
-  security-events: write
 
 jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout PR code
         uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run Trivy vulnerability scanner (filesystem)
-        uses: aquasecurity/trivy-action@master
+        id: trivy
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
           format: 'sarif'
           output: 'trivy-fs-results.sarif'
-          severity: 'CRITICAL,HIGH,MEDIUM'
 
+      # Code scanning uploads need a write token, which fork and Dependabot runs
+      # never get. Skip the upload there rather than fail the scan on a 403.
+      # The leading success() only restates the default: GitHub applies success()
+      # to any if: without a status-check function, so this step and the two
+      # below already run only when the scan succeeded.
+      # continue-on-error keeps a failed upload from failing the job, so that
+      # default success() on the two steps below stays true and the artifact
+      # fallback still runs; outcome remains 'failure' for them to read.
       - name: Upload Trivy filesystem results to GitHub Security
+        id: code_scanning
+        continue-on-error: true
+        if: >-
+          success() &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]'
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-fs-results.sarif'
           category: 'trivy-filesystem'
+
+      # Whenever there is a report but code scanning did not take it, whether it
+      # was skipped on a fork run or failed outright. Reading both outcomes
+      # rather than restating the condition inverted keeps the two in step, and
+      # gating on the scan means a failed scan produces one error, not three.
+      - name: Upload Trivy results as an artifact
+        id: trivy_artifact
+        if: >-
+          steps.trivy.outcome == 'success' &&
+          steps.code_scanning.outcome != 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: trivy-fs-results
+          path: trivy-fs-results.sarif
+          if-no-files-found: error
+          retention-days: 7
+
+      # A retained artifact nobody knows about is still a lost report.
+      - name: Say where the Trivy report went
+        if: steps.trivy_artifact.outcome == 'success'
+        run: |
+          {
+            echo "## Trivy"
+            echo ""
+            echo "Code scanning did not take this report, either because the run has no"
+            echo "permission to upload or because the upload failed. It is attached as the"
+            echo "\`trivy-fs-results\` artifact instead: ${{ steps.trivy_artifact.outputs.artifact-url }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   lint:
     name: Lint
@@ -44,8 +87,6 @@ jobs:
     steps:
       - name: Checkout PR code
         uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Go
         uses: actions/setup-go@v6
@@ -72,8 +113,6 @@ jobs:
     steps:
       - name: Checkout PR code
         uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Go
         uses: actions/setup-go@v6
@@ -89,12 +128,17 @@ jobs:
 
       - name: Setup envtest
         run: |
-          go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+          # renovate: datasource=go depName=sigs.k8s.io/controller-runtime/tools/setup-envtest
+          go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.24.1
           setup-envtest use
 
       - name: Run tests
         run: |
-          export KUBEBUILDER_ASSETS="$(setup-envtest use -p path)"
+          # Assign and export separately: export is a builtin whose own exit
+          # status masks a failing command substitution, so a broken
+          # setup-envtest would otherwise run the suite with no assets at all.
+          KUBEBUILDER_ASSETS="$(setup-envtest use -p path)"
+          export KUBEBUILDER_ASSETS
           go test -v -race -tags=envtest -coverprofile=coverage.out -covermode=atomic $(go list ./... | grep -v /test/e2e)
 
       - name: Upload coverage
@@ -111,13 +155,13 @@ jobs:
       - name: Checkout PR code
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Set up Helm
         uses: azure/setup-helm@v5
         with:
-          version: 'latest'
+          # renovate: datasource=github-releases depName=helm/helm
+          version: v4.2.3
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -129,7 +173,8 @@ jobs:
 
       - name: Install tools
         run: |
-          helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
+          # renovate: datasource=github-releases depName=helm-unittest/helm-unittest
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.1.2 --verify=false
           pip install check-jsonschema
 
       - name: Run Helm Lint
@@ -176,8 +221,6 @@ jobs:
     steps:
       - name: Checkout PR code
         uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -190,8 +233,12 @@ jobs:
           file: ./Containerfile
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=ttl.sh/wish-operator,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=build-${{ matrix.arch }}
-          cache-to: type=gha,scope=build-${{ matrix.arch }},mode=max
+          # No build cache. Per-PR scopes multiply the repository budget by the
+          # number of open branches, and nothing writes a scope a PR can read.
+          # The image is built from the merge commit, but REVISION names the
+          # head commit: the merge SHA is ephemeral and unresolvable once the
+          # PR moves on, and the delta between them is base-branch code the PR
+          # already identifies. The mismatch is deliberate, not an oversight.
           build-args: |
             VERSION=pr-${{ github.event.pull_request.number }}
             REVISION=${{ github.event.pull_request.head.sha }}
@@ -279,13 +326,12 @@ jobs:
     steps:
       - name: Checkout PR code
         uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v5
         with:
-          version: 'latest'
+          # renovate: datasource=github-releases depName=helm/helm
+          version: v4.2.3
 
       - name: Modify Chart.yaml and values.yaml
         run: |
@@ -348,6 +394,18 @@ jobs:
     name: Notify PR
     needs: [merge-manifests, build-chart]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    # Labelling and commenting need a write token, which fork and Dependabot
+    # runs never get, so those PRs no longer get the image and chart comment.
+    # The leading success() only restates the default GitHub applies to an if:
+    # without a status-check function, so this runs only when the needed jobs
+    # succeeded and never advertises an image the build did not push.
+    if: >-
+      success() &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     steps:
       - name: Check if first build
         id: first_build


### PR DESCRIPTION
The PR workflow ran on `pull_request_target`, which handed the job an elevated token (`pull-requests: write`, `security-events: write`) while it checked out the PR head commit and ran that code through `go test`, `templ generate`, and `golangci-lint`. That is the classic pwn-request setup: a fork PR could execute arbitrary code with a write token and poison the shared Actions cache.

This switches the trigger to `pull_request` and drops the explicit `head.sha` checkout refs. Those refs are legal under either trigger, so removing them is a deliberate change: CI now tests `refs/pull/N/merge`, the result of merging, instead of the head commit. That is a better basis for deciding whether a PR is safe to land. One cost worth naming: a conflicted PR has no merge ref, so checkout fails outright instead of running the suite. `REVISION` still names the head commit, because the merge SHA is unresolvable once the PR moves on. No secrets are involved anywhere in the build path, since ttl.sh is anonymous.

It also narrows the token. The workflow-wide `permissions` block handed `pull-requests: write` and `security-events: write` to every job, including the ones that run branch-controlled code. GitHub downgrades the token on fork pull requests anyway, but Renovate branches live in this repository and get no such treatment, so a dependency bump ran freshly pulled third-party code with a write token. The workflow default is now `contents: read`, and the `security` and `notify` jobs declare the extra scope they need.

The build is fixed too. `Build and Push` has been red on every PR since early July with `failed to reserve cache`. The Actions cache went read-only for untrusted triggers on 2026-06-26, and `pull_request_target` is one of them, so the export was rejected and failed the build with it. Switching the trigger restores the export on its own.

The build cache goes away in both directions. Exporting would multiply the repository's 10 GB budget by the number of open branches, since every pull request gets its own scope under `pull_request`, and one PR alone reached 96 entries and 4 GB while this was being tested. Importing has nothing to read either: `release.yaml` writes scope `build-linux-<arch>` and only on tag pushes, which no pull request can restore from, and the two entries a PR does find on the default branch were last written on 2026-06-24 by the old trigger, which sent every PR's export into the master scope. Removing that writer would leave the reader with a frozen snapshot whose blobs are already being evicted. Warming a shared scope from the default branch is what would make a cache worth having here.

Two jobs lose something, and both are guarded instead of left to fail:

- `notify` adds a label and a comment, which needs a write token, so it now skips on fork and Dependabot PRs. Those PRs stop getting the image comment.
- the code scanning upload needs `security-events: write`, so it skips on those runs too. Those runs attach the report as a build artifact instead, so the findings stay reachable rather than dying with the runner.

Dependabot is the case that matters here rather than forks. This repo gets Dependabot security updates, and those run read-only under `pull_request` regardless of what the `permissions` block asks for.

Five smaller fixes in the same file: react to `reopened`, so a reopened PR rebuilds instead of sitting on stale required checks; install `setup-envtest` at the controller-runtime version from `go.mod` rather than `@latest`, matching how `templ` is already installed; pin Helm and the helm-unittest plugin, after `Lint Chart` failed three runs in a row today when the plugin published a release mid-run and the unpinned install raced it; drop the `severity` input on the Trivy scan, which the action unsets whenever the format is `sarif` and `limit-severities-for-sarif` is not set, so it never filtered anything; and pin `trivy-action` to a release tag instead of the mutable `master` ref.
