### PR TITLE
fix(web): use trusted XFF entry and evict idle rate limiters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,14 +12,14 @@ Users describe desired gifts as Kubernetes CRD resources (`Wish`). The operator 
 - **CRD API**: `wishlist.k8s.lex.la/v1alpha1`
 - **Controller**: controller-runtime
 - **Web**: HTMX + a-h/templ
-- **CLI**: cobra + viper
+- **CLI**: stdlib `flag`
 - **Testing**: testify + envtest
 
 ## Project Structure
 
 ```
 api/v1alpha1/          # CRD types (Wish)
-cmd/operator/          # Entry point
+cmd/                   # Entry point (main.go)
 internal/controller/   # Reconciler logic
 internal/web/          # HTTP server + handlers
 internal/templates/    # Templ files
@@ -30,13 +30,13 @@ charts/wish-operator/  # Helm chart
 
 ```bash
 # Generate deepcopy and CRD manifests
-go generate ./...
+make manifests generate
 
 # Run tests
 go test ./...
 
 # Build
-go build -o bin/operator ./cmd/operator
+make build
 
 # Lint
 golangci-lint run
@@ -57,19 +57,21 @@ This project follows strict TDD:
 **Spec fields**:
 - `title` (string, required): Item name
 - `imageURL` (string): Product image
-- `productURL` (string): Link to buy
+- `officialURL` (string): Manufacturer or product page
+- `purchaseURLs` ([]string): Places to buy it
 - `msrp` (string): Price display
 - `tags` ([]string): Category tags
 - `contextTags` ([]string): "For:" section
 - `description` (string): Why user wants this
-- `priority` (int32, 1-5): Displayed as stars
-- `ttl` (metav1.Duration): How long wish stays active
+- `priority` (int32, 0-5): Displayed as stars; 0 means unset and renders none
+- `quantity` (int32, default 1): How many are wanted; 0 means unlimited
+- `ttl` (*metav1.Duration): How long wish stays active
 
 **Status fields**:
-- `reserved` (bool): Is reserved
-- `reservedAt` (*metav1.Time): When reserved
-- `reservationExpires` (*metav1.Time): When reservation expires
+- `reservations` ([]Reservation): Active reservations, each with `quantity`, `createdAt`, `expiresAt`
 - `active` (bool): Within TTL
+- `conditions` ([]metav1.Condition): Declared on the type; the controller does not populate it yet
+- Deprecated, kept for migration off the single-reservation model: `reserved` (bool), `reservedAt` (*metav1.Time), `reservationExpires` (*metav1.Time)
 
 ## Kubernetes Context
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Kubernetes operator for managing wishlists. Create wishes as Kubernetes resource
 
 ## Features
 
-- **Wish CRD** — define wishes with title, description, price, images, priority (1-5 stars), and tags
+- **Wish CRD** — define wishes with title, description, price, images, priority (0-5 stars), and tags
 - **Quantity support** — specify multiple items per wish, reserve partially
 - **Web UI** — HTMX-powered interface for viewing and reserving wishes
 - **Reservations** — multiple anonymous reservations per wish, 1-8 weeks with automatic expiration
 - **TTL** — wishes can auto-expire after a defined duration
-- **Rate limiting** — per-IP rate limiting to prevent abuse
+- **Rate limiting** — per-IP rate limiting to prevent abuse, see [Client addresses behind a proxy](#client-addresses-behind-a-proxy)
 - **Gateway API** — HTTPRoute support for ingress via Gateway API
 
 ## Installation
@@ -72,7 +72,7 @@ spec:
 | `officialURL` | string | Official product page |
 | `purchaseURLs` | []string | Links where to buy |
 | `imageURL` | string | Product image URL |
-| `priority` | int32 | Importance 1-5 (displayed as stars) |
+| `priority` | int32 | Importance 0-5 (displayed as stars; 0 renders none) |
 | `tags` | []string | Category labels |
 | `contextTags` | []string | Occasions (birthday, christmas) |
 | `ttl` | duration | Auto-expire after this duration |
@@ -97,15 +97,30 @@ spec:
 | `operator.namespace` | default | Namespace to watch for Wishes |
 | `operator.rateLimit` | 30 | Requests per second per IP |
 | `operator.rateBurst` | 10 | Burst size for rate limiting |
+| `operator.trustedProxyHops` | 0 | Proxies in front that append to `X-Forwarded-For` (0 ignores the header) |
 | `httpRoute.enabled` | false | Create HTTPRoute resource |
 | `httpRoute.hostnames` | [] | Hostnames for the route |
 | `httpRoute.parentRefs` | [] | Gateway references |
+
+> **Upgrading from an earlier release behind a proxy:** set `operator.trustedProxyHops` as part of the upgrade. Earlier versions read the leftmost `X-Forwarded-For` entry, which a caller could set to anything; the header is now ignored unless you say what sits in front. Leaving it at the default puts every visitor arriving through your gateway into one shared bucket, because they all reach the operator from the same address. See [Client addresses behind a proxy](#client-addresses-behind-a-proxy).
+
+### Client addresses behind a proxy
+
+Rate limiting buckets requests by client address, and how that address is read depends on what sits in front of the operator. With the default `operator.trustedProxyHops: 0` the connection address is used and `X-Forwarded-For` is ignored, because a directly reachable server has no way to tell a real header from one the caller made up.
+
+Set `operator.trustedProxyHops` to the number of proxies that append to `X-Forwarded-For` on the way in — one for a single gateway, two when a CDN or tunnel fronts that gateway. The operator then counts that many entries from the right of the header, which is where the outermost proxy wrote the address it saw. Counting from the left instead would read whatever the caller sent, so a caller could rotate values and never hit the limit.
+
+IPv6 clients are bucketed by `/64` rather than by address, because a single subscriber is normally handed a whole `/64` and would otherwise get a fresh allowance for every address in it. IPv4 clients are bucketed per address.
+
+A hop count above zero also assumes the operator is reachable *only* through that chain. A ClusterIP Service is reachable directly by any other pod in the cluster, and such a caller picks its own `X-Forwarded-For` outright, so restrict traffic to the gateway with a NetworkPolicy if in-cluster callers are a concern.
+
+Set it too low and every visitor collapses onto the address of a proxy in the chain, sharing one bucket. Set it higher than the real chain and a caller can supply the entry that gets used. `X-Real-IP` is never read: proxies that append to `X-Forwarded-For` pass it through untouched. A proxy configured to set only `X-Real-IP`, as an nginx with a lone `proxy_set_header X-Real-IP` does, leaves nothing to count, so configure it to append to `X-Forwarded-For` as well.
 
 ## Development
 
 ### Prerequisites
 
-- Go 1.25+
+- Go 1.26+
 - kubectl
 - Helm 3
 - [helm-unittest](https://github.com/helm-unittest/helm-unittest)

--- a/charts/wish-operator/templates/NOTES.txt
+++ b/charts/wish-operator/templates/NOTES.txt
@@ -1,0 +1,12 @@
+wish-operator is watching namespace {{ .Values.operator.namespace | default "default" }}.
+
+Rate limiting: {{ .Values.operator.rateLimit | default 30 }} requests per second per client, burst {{ .Values.operator.rateBurst | default 10 }}.
+{{ if and (or .Values.httpRoute.enabled (ne .Values.service.type "ClusterIP")) (not .Values.operator.trustedProxyHops) }}
+WARNING: this release is reachable through a proxy or load balancer but
+operator.trustedProxyHops is 0, so X-Forwarded-For is ignored and every visitor
+reaching the operator from the same address shares one rate limit bucket.
+
+Set operator.trustedProxyHops to the number of proxies that append to
+X-Forwarded-For on the way in: 1 for a single gateway, 2 when a CDN or tunnel
+fronts it. Leave it at 0 only when the service is reached directly.
+{{- end }}

--- a/charts/wish-operator/templates/deployment.yaml
+++ b/charts/wish-operator/templates/deployment.yaml
@@ -36,9 +36,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --web-bind-address=:8080
-            - --web-namespace={{ .Values.operator.namespace }}
-            - --rate-limit={{ .Values.operator.rateLimit }}
-            - --rate-burst={{ .Values.operator.rateBurst }}
+            {{- /* every flag falls back to its default, so an upgrade that drops new chart defaults, such as --reuse-values, cannot render an empty value the binary refuses to start on */}}
+            - --web-namespace={{ .Values.operator.namespace | default "default" }}
+            - --rate-limit={{ .Values.operator.rateLimit | default 30 }}
+            - --rate-burst={{ .Values.operator.rateBurst | default 10 }}
+            - --trusted-proxy-hops={{ .Values.operator.trustedProxyHops | default 0 }}
             - --health-probe-bind-address=:8081
             {{- if .Values.operator.leaderElection }}
             - --leader-elect

--- a/charts/wish-operator/tests/deployment_test.yaml
+++ b/charts/wish-operator/tests/deployment_test.yaml
@@ -244,6 +244,57 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --rate-burst=20
 
+  - it: should not trust proxy headers by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --trusted-proxy-hops=0
+
+  - it: should allow declaring trusted proxy hops
+    set:
+      operator:
+        trustedProxyHops: 2
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --trusted-proxy-hops=2
+
+  - it: should render trusted proxy hops when the value is absent
+    set:
+      operator:
+        trustedProxyHops: null
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --trusted-proxy-hops=0
+
+  - it: should render the watched namespace when the value is absent
+    set:
+      operator:
+        namespace: null
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --web-namespace=default
+
+  - it: should render rate limit when the value is absent
+    set:
+      operator:
+        rateLimit: null
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --rate-limit=30
+
+  - it: should render rate burst when the value is absent
+    set:
+      operator:
+        rateBurst: null
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --rate-burst=10
+
   - it: should not enable leader election by default
     asserts:
       - notContains:

--- a/charts/wish-operator/tests/notes_test.yaml
+++ b/charts/wish-operator/tests/notes_test.yaml
@@ -1,0 +1,67 @@
+suite: notes tests
+templates:
+  - NOTES.txt
+tests:
+  - it: should warn when a gateway is in front but no hops are declared
+    set:
+      httpRoute:
+        enabled: true
+      operator:
+        trustedProxyHops: 0
+    asserts:
+      - matchRegex:
+          path: raw
+          pattern: "WARNING: this release is reachable through a proxy or load balancer"
+
+  - it: should not warn once the hop count is declared
+    set:
+      httpRoute:
+        enabled: true
+      operator:
+        trustedProxyHops: 1
+    asserts:
+      - notMatchRegex:
+          path: raw
+          pattern: "WARNING"
+
+  - it: should warn for a LoadBalancer service without declared hops
+    set:
+      service:
+        type: LoadBalancer
+      operator:
+        trustedProxyHops: 0
+    asserts:
+      - matchRegex:
+          path: raw
+          pattern: "WARNING"
+
+  - it: should warn for a NodePort service without declared hops
+    set:
+      service:
+        type: NodePort
+      operator:
+        trustedProxyHops: 0
+    asserts:
+      - matchRegex:
+          path: raw
+          pattern: "WARNING"
+
+  - it: should not warn without a gateway or an exposed service
+    set:
+      httpRoute:
+        enabled: false
+      service:
+        type: ClusterIP
+    asserts:
+      - notMatchRegex:
+          path: raw
+          pattern: "WARNING"
+
+  - it: should report the watched namespace
+    set:
+      operator:
+        namespace: wishlist-ns
+    asserts:
+      - matchRegex:
+          path: raw
+          pattern: "watching namespace wishlist-ns"

--- a/charts/wish-operator/values.schema.json
+++ b/charts/wish-operator/values.schema.json
@@ -293,7 +293,7 @@
           "minimum": 1,
           "maximum": 1000,
           "default": 30,
-          "description": "Rate limit (requests per minute per IP)"
+          "description": "Rate limit (requests per second per IP)"
         },
         "rateBurst": {
           "type": "integer",
@@ -301,6 +301,13 @@
           "maximum": 100,
           "default": 10,
           "description": "Rate limit burst size"
+        },
+        "trustedProxyHops": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10,
+          "default": 0,
+          "description": "Number of proxies in front that append to X-Forwarded-For (0 ignores the header)"
         },
         "leaderElection": {
           "type": "boolean",

--- a/charts/wish-operator/values.yaml
+++ b/charts/wish-operator/values.yaml
@@ -53,6 +53,12 @@ operator:
   namespace: default
   rateLimit: 30
   rateBurst: 10
+  # Number of proxies in front of the web server that append to X-Forwarded-For.
+  # Rate limiting reads the client address that many entries from the right of
+  # the header. Keep at 0 unless such a proxy is in front: with 0 the header is
+  # ignored and the connection address is used, because anything else is
+  # supplied by the caller and lets it pick its own rate limit bucket.
+  trustedProxyHops: 0
   leaderElection: false
 
 # Gateway API HTTPRoute

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,8 +8,11 @@ import (
 	"crypto/tls"
 	"errors"
 	"flag"
+	"fmt"
+	"math"
 	"net/http"
 	"os"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -19,6 +22,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -43,6 +47,82 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
+const (
+	// webReadHeaderTimeout bounds how long a caller may take to send headers.
+	webReadHeaderTimeout = 10 * time.Second
+	// webShutdownTimeout bounds how long in-flight requests get to finish.
+	webShutdownTimeout = 5 * time.Second
+)
+
+// webOptions groups the settings of the public wishlist web server.
+type webOptions struct {
+	namespace        string
+	trustedProxyHops int
+	rateLimit        float64
+	rateBurst        int
+}
+
+// bindWebFlags registers the web server flags on flagSet.
+func bindWebFlags(flagSet *flag.FlagSet, opts *webOptions) {
+	flagSet.StringVar(&opts.namespace, "web-namespace", "default", "The namespace to watch for Wish resources.")
+	flagSet.IntVar(&opts.trustedProxyHops, "trusted-proxy-hops", 0,
+		"Number of proxies in front of the web server that append to X-Forwarded-For. "+
+			"Rate limiting reads the client address from that many entries counted from the right. "+
+			"Leave at 0 when the server is reachable directly, so proxy headers are ignored.")
+	flagSet.Float64Var(&opts.rateLimit, "rate-limit", 30, "Rate limit requests per second per IP.")
+	flagSet.IntVar(&opts.rateBurst, "rate-burst", 10, "Rate limit burst size.")
+}
+
+// Errors returned by validateWebFlags.
+var (
+	errEmptyNamespace    = errors.New("--web-namespace must not be empty")
+	errNegativeProxyHops = errors.New("--trusted-proxy-hops must not be negative")
+	errRateLimitInvalid  = errors.New("--rate-limit must be a finite number greater than zero")
+	errRateBurstTooLow   = errors.New("--rate-burst must be at least one")
+)
+
+// newWebServer maps parsed flags onto the web server. web.NewServer takes its
+// arguments positionally and two of them are ints, so a transposition compiles
+// and runs; this is the single place that mapping is written down, and the
+// place a test can pin it.
+func newWebServer(c client.Client, opts *webOptions) *web.Server {
+	return web.NewServer(c, opts.namespace, opts.trustedProxyHops, opts.rateLimit, opts.rateBurst)
+}
+
+// validateWebFlags rejects settings the flag package cannot express. Each one
+// is a value the binary would otherwise accept and then misbehave on: a
+// negative hop count reads like "trust one proxy" but disables proxy headers,
+// and a zero rate or burst refuses every single request with 429 rather than
+// limiting anything.
+//
+// Non-finite rates matter most, because they are the only ones that fail open.
+// NaN passes every ordered comparison, so it survives a bare "<= 0" check and
+// then makes the limiter allow everything; +Inf is rate.Inf, which is
+// unlimited by definition. Both turn rate limiting off with nothing in the log
+// to say so, and neither is a rate anybody means to ask for.
+func validateWebFlags(opts *webOptions) error {
+	// An empty namespace is not a narrower scope, it is every namespace: the
+	// client treats it as cluster-wide on list, and the public page would serve
+	// every Wish in the cluster while every reservation failed to resolve.
+	if opts.namespace == "" {
+		return errEmptyNamespace
+	}
+
+	if opts.trustedProxyHops < 0 {
+		return fmt.Errorf("%w, got %d", errNegativeProxyHops, opts.trustedProxyHops)
+	}
+
+	if math.IsNaN(opts.rateLimit) || math.IsInf(opts.rateLimit, 0) || opts.rateLimit <= 0 {
+		return fmt.Errorf("%w, got %v", errRateLimitInvalid, opts.rateLimit)
+	}
+
+	if opts.rateBurst < 1 {
+		return fmt.Errorf("%w, got %d", errRateBurstTooLow, opts.rateBurst)
+	}
+
+	return nil
+}
+
 // nolint:gocyclo
 func main() {
 	var metricsAddr string
@@ -51,9 +131,9 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var webAddr string
-	var webNamespace string
-	var rateLimit float64
-	var rateBurst int
+
+	var webOpts webOptions
+
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var tlsOpts []func(*tls.Config)
@@ -61,9 +141,7 @@ func main() {
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&webAddr, "web-bind-address", ":8080", "The address the web server binds to.")
-	flag.StringVar(&webNamespace, "web-namespace", "default", "The namespace to watch for Wish resources.")
-	flag.Float64Var(&rateLimit, "rate-limit", 30, "Rate limit requests per minute per IP.")
-	flag.IntVar(&rateBurst, "rate-burst", 10, "Rate limit burst size.")
+	bindWebFlags(flag.CommandLine, &webOpts)
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -85,6 +163,11 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	if err := validateWebFlags(&webOpts); err != nil {
+		setupLog.Error(err, "invalid web server flags")
+		os.Exit(1)
+	}
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
@@ -196,12 +279,15 @@ func main() {
 	}
 
 	// Start web server
-	webServer := web.NewServer(mgr.GetClient(), webNamespace, rateLimit, rateBurst)
+	webServer := newWebServer(mgr.GetClient(), &webOpts)
 	if err := mgr.Add(&webRunnable{addr: webAddr, handler: webServer.Handler()}); err != nil {
 		setupLog.Error(err, "unable to add web server")
 		os.Exit(1)
 	}
-	setupLog.Info("web server configured", "address", webAddr, "namespace", webNamespace)
+	setupLog.Info("web server configured",
+		"address", webAddr,
+		"namespace", webOpts.namespace,
+		"trustedProxyHops", webOpts.trustedProxyHops)
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
@@ -214,27 +300,49 @@ func main() {
 type webRunnable struct {
 	addr    string
 	handler http.Handler
+	// shutdownTimeout overrides webShutdownTimeout; zero means the default.
+	shutdownTimeout time.Duration
 }
 
 func (w *webRunnable) Start(ctx context.Context) error {
 	server := &http.Server{
 		Addr:              w.addr,
 		Handler:           w.handler,
-		ReadHeaderTimeout: 10 * 1000000000, // 10 seconds in nanoseconds
+		ReadHeaderTimeout: webReadHeaderTimeout,
+	}
+
+	drained := make(chan struct{})
+
+	timeout := w.shutdownTimeout
+	if timeout == 0 {
+		timeout = webShutdownTimeout
 	}
 
 	go func() {
+		defer close(drained)
+
 		<-ctx.Done()
 
-		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*1000000000)
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
 		defer cancel()
 
-		_ = server.Shutdown(shutdownCtx)
+		// A timeout here means in-flight responses were cut mid-write. The
+		// runnable still stops cleanly, so without this line the only trace of
+		// a truncated rollout would be on the client side.
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			setupLog.Error(err, "web server shutdown did not drain in time", "timeout", timeout)
+		}
 	}()
 
 	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return err
 	}
+
+	// Shutdown closes the listeners first, so ListenAndServe returns while
+	// requests are still being served. Returning here would let the manager
+	// count this runnable as stopped and the process exit mid-response, which
+	// would make the shutdown timeout above mean nothing.
+	<-drained
 
 	return nil
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,507 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025 Aleksei Sviridkin
+
+package main
+
+import (
+	"context"
+	"flag"
+	"io"
+	"math"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	wishlistv1alpha1 "github.com/lexfrei/wish-operator/api/v1alpha1"
+)
+
+func newWebFlagSet(t *testing.T) (*flag.FlagSet, *webOptions) {
+	t.Helper()
+
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	flagSet.SetOutput(io.Discard)
+
+	opts := &webOptions{}
+	bindWebFlags(flagSet, opts)
+
+	return flagSet, opts
+}
+
+func TestBindWebFlags_Defaults(t *testing.T) {
+	t.Parallel()
+
+	flagSet, opts := newWebFlagSet(t)
+	require.NoError(t, flagSet.Parse(nil))
+
+	assert.Equal(t, "default", opts.namespace)
+	assert.InDelta(t, 30.0, opts.rateLimit, 0)
+	assert.Equal(t, 10, opts.rateBurst)
+	// Proxy headers are forgeable unless an operator declares what sits in
+	// front, so the default must not trust them.
+	assert.Equal(t, 0, opts.trustedProxyHops)
+}
+
+func TestBindWebFlags_Parse(t *testing.T) {
+	t.Parallel()
+
+	flagSet, opts := newWebFlagSet(t)
+	require.NoError(t, flagSet.Parse([]string{
+		"--web-namespace=wishes",
+		"--trusted-proxy-hops=2",
+		"--rate-limit=5",
+		"--rate-burst=3",
+	}))
+
+	assert.Equal(t, "wishes", opts.namespace)
+	assert.Equal(t, 2, opts.trustedProxyHops)
+	assert.InDelta(t, 5.0, opts.rateLimit, 0)
+	assert.Equal(t, 3, opts.rateBurst)
+}
+
+// mainInvalidFlagHelperEnv makes the re-invoked test binary run main() instead
+// of the test body, which is how main's own wiring gets exercised.
+const mainInvalidFlagHelperEnv = "TEST_MAIN_INVALID_WEB_FLAGS"
+
+// TestMain_ExitsOnInvalidWebFlags pins that main actually calls the validator
+// and refuses to start, rather than validating in a function nobody reaches.
+// The child gets a kubeconfig that cannot exist, so if the check were dropped
+// it would still exit non-zero — the assertion is on the message, which only
+// the validator produces.
+func TestMain_ExitsOnInvalidWebFlags(t *testing.T) {
+	if os.Getenv(mainInvalidFlagHelperEnv) == "1" {
+		// Replace the test binary's arguments so main parses these instead.
+		os.Args = []string{"operator", "--rate-limit=NaN"}
+
+		main()
+
+		return
+	}
+
+	t.Parallel()
+
+	// os.Args[0] is this very test binary, re-invoked to reach main().
+	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=TestMain_ExitsOnInvalidWebFlags")
+	cmd.Env = append(os.Environ(),
+		mainInvalidFlagHelperEnv+"=1",
+		"KUBECONFIG=/nonexistent/kubeconfig",
+	)
+
+	out, err := cmd.CombinedOutput()
+
+	var exitErr *exec.ExitError
+
+	require.ErrorAs(t, err, &exitErr, "main must exit non-zero, got output: %s", out)
+	assert.Equal(t, 1, exitErr.ExitCode())
+	assert.Contains(t, string(out), "--rate-limit must be a finite number greater than zero")
+}
+
+// freePort returns an address nothing is listening on. The port could in
+// principle be taken between the close and the bind below; nothing else in this
+// suite binds ports, so the window is not worth a listener-injection refactor.
+func freePort(t *testing.T) string {
+	t.Helper()
+
+	var config net.ListenConfig
+
+	listener, err := config.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	addr := listener.Addr().String()
+	require.NoError(t, listener.Close())
+
+	return addr
+}
+
+// TestWebRunnable_StartWaitsForDrain pins that Start does not report the
+// runnable as stopped while a request is still being served. Shutdown closes
+// the listeners first, so ListenAndServe returns immediately; if Start returned
+// then, the manager would move on, the process would exit, and the shutdown
+// timeout would bound nothing.
+// Not parallel: it binds a port, and running alongside the other bind test
+// races for the one freePort just released.
+func TestWebRunnable_StartWaitsForDrain(t *testing.T) {
+	var (
+		handlerEntered = make(chan struct{})
+		handlerDone    atomic.Bool
+	)
+
+	const handlerWork = 300 * time.Millisecond
+
+	runnable := &webRunnable{
+		addr: freePort(t),
+		handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			close(handlerEntered)
+			time.Sleep(handlerWork)
+
+			_, _ = w.Write([]byte("done"))
+
+			handlerDone.Store(true)
+		}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	startErr := make(chan error, 1)
+
+	go func() { startErr <- runnable.Start(ctx) }()
+
+	// Wait for the listener. Firing the request before the bind would fail the
+	// connection, and then nothing would ever enter the handler to wait on.
+	var dialer net.Dialer
+
+	require.Eventually(t, func() bool {
+		conn, err := dialer.DialContext(t.Context(), "tcp", runnable.addr)
+		if err != nil {
+			return false
+		}
+
+		return conn.Close() == nil
+	}, 5*time.Second, 10*time.Millisecond, "web server never started listening")
+
+	body := make(chan string, 1)
+
+	go func() {
+		resp, err := http.Get("http://" + runnable.addr + "/") //nolint:noctx // the cancel under test is server-side
+		if err != nil {
+			body <- "request failed: " + err.Error()
+
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		got, err := io.ReadAll(resp.Body)
+		if err != nil {
+			body <- "read failed: " + err.Error()
+
+			return
+		}
+
+		body <- string(got)
+	}()
+
+	select {
+	case <-handlerEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("request never reached the handler")
+	}
+
+	cancel()
+
+	require.NoError(t, <-startErr)
+	assert.True(t, handlerDone.Load(), "Start returned while a request was still in flight")
+	assert.Equal(t, "done", <-body, "the in-flight response must arrive complete")
+}
+
+// TestWebRunnable_StartReturnsBindError pins that the drain wait does not turn
+// a failed bind into a hang: ListenAndServe returns before anything can be
+// draining, and the shutdown goroutine is still parked on the context.
+// Not parallel: it holds a port open for the whole test, see above.
+func TestWebRunnable_StartReturnsBindError(t *testing.T) {
+	var config net.ListenConfig
+
+	occupied, err := config.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	defer func() { _ = occupied.Close() }()
+
+	runnable := &webRunnable{
+		addr:    occupied.Addr().String(),
+		handler: http.NewServeMux(),
+	}
+
+	startErr := make(chan error, 1)
+
+	go func() { startErr <- runnable.Start(t.Context()) }()
+
+	select {
+	case err := <-startErr:
+		require.Error(t, err, "a failed bind must be reported, not swallowed")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start blocked instead of returning the bind error")
+	}
+}
+
+// recordingSink captures Error calls so a test can assert the operator was
+// told something, rather than only that the code took a branch.
+type recordingSink struct {
+	mu   sync.Mutex
+	errs []string
+}
+
+func (s *recordingSink) Init(logr.RuntimeInfo)        {}
+func (s *recordingSink) Enabled(int) bool             { return true }
+func (s *recordingSink) Info(int, string, ...any)     {}
+func (s *recordingSink) WithName(string) logr.LogSink { return s }
+
+func (s *recordingSink) WithValues(...any) logr.LogSink { return s }
+
+func (s *recordingSink) Error(err error, msg string, _ ...any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.errs = append(s.errs, msg+": "+err.Error())
+}
+
+func (s *recordingSink) recorded() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return slices.Clone(s.errs)
+}
+
+// TestWebRunnable_ReportsShutdownTimeout pins that a drain which runs out of
+// time is not silent. The runnable still stops cleanly, so the log line is the
+// only signal an operator gets that responses were cut mid-write.
+// Not parallel: it binds a port and swaps the package logger, see above.
+func TestWebRunnable_ReportsShutdownTimeout(t *testing.T) {
+	sink := &recordingSink{}
+	original := setupLog
+	setupLog = logr.New(sink)
+
+	t.Cleanup(func() { setupLog = original })
+
+	handlerEntered := make(chan struct{})
+
+	runnable := &webRunnable{
+		addr: freePort(t),
+		handler: http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			close(handlerEntered)
+			// Outlast the shutdown budget below.
+			time.Sleep(2 * time.Second)
+		}),
+		shutdownTimeout: 50 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	startErr := make(chan error, 1)
+
+	go func() { startErr <- runnable.Start(ctx) }()
+
+	var dialer net.Dialer
+
+	require.Eventually(t, func() bool {
+		conn, err := dialer.DialContext(t.Context(), "tcp", runnable.addr)
+		if err != nil {
+			return false
+		}
+
+		return conn.Close() == nil
+	}, 5*time.Second, 10*time.Millisecond, "web server never started listening")
+
+	go func() {
+		//nolint:noctx // the cancellation under test is server-side
+		resp, err := http.Get("http://" + runnable.addr + "/")
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	select {
+	case <-handlerEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("request never reached the handler")
+	}
+
+	cancel()
+
+	require.NoError(t, <-startErr, "a timed-out drain still stops the runnable cleanly")
+
+	recorded := sink.recorded()
+	require.Len(t, recorded, 1, "the timeout must be reported exactly once")
+	assert.Contains(t, recorded[0], "web server shutdown did not drain in time")
+	assert.Contains(t, recorded[0], context.DeadlineExceeded.Error())
+}
+
+// TestNewWebServer_MapsFlagsOntoTheServer pins the construction seam. Two of
+// web.NewServer's parameters are ints, so transposing the hop count and the
+// burst compiles, runs, and silently ships a server configured with neither
+// value the operator asked for. The values below are picked so that a swap
+// changes observable behaviour: with hops 2 the middle entry is the key and one
+// token is available, while the swapped pair keys on the last entry and hands
+// out two.
+func TestNewWebServer_MapsFlagsOntoTheServer(t *testing.T) {
+	t.Parallel()
+
+	const (
+		proxyAppended = "203.0.113.7"
+		innerProxy    = "198.51.100.5"
+		watched       = "wishes"
+	)
+
+	newServerFor := func(opts *webOptions, wishes ...client.Object) http.Handler {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(wishes...).
+			Build()
+
+		return newWebServer(fakeClient, opts).Handler()
+	}
+
+	t.Run("hop count and burst are not transposed", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newServerFor(&webOptions{
+			namespace:        watched,
+			trustedProxyHops: 2,
+			rateLimit:        1,
+			rateBurst:        1,
+		})
+
+		get := func(forged string) int {
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+			req.RemoteAddr = "10.0.0.1:5000"
+			req.Header.Set("X-Forwarded-For", forged+", "+proxyAppended+", "+innerProxy)
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			return rec.Code
+		}
+
+		require.Equal(t, http.StatusOK, get("1.1.1.1"), "the single burst token should be available")
+		assert.Equal(t, http.StatusTooManyRequests, get("2.2.2.2"),
+			"both requests key on the entry two hops from the right, and only one token exists")
+	})
+
+	t.Run("the watched namespace is passed through", func(t *testing.T) {
+		t.Parallel()
+
+		const title = "Namespaced Gift"
+
+		wish := &wishlistv1alpha1.Wish{
+			ObjectMeta: metav1.ObjectMeta{Name: "namespaced-wish", Namespace: watched},
+			Spec:       wishlistv1alpha1.WishSpec{Title: title},
+			Status:     wishlistv1alpha1.WishStatus{Active: true},
+		}
+
+		handler := newServerFor(&webOptions{
+			namespace:        watched,
+			trustedProxyHops: 0,
+			rateLimit:        30,
+			rateBurst:        10,
+		}, wish)
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil))
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), title)
+	})
+}
+
+func TestValidateWebFlags(t *testing.T) {
+	t.Parallel()
+
+	// Start from a valid set and break one field per case.
+	valid := webOptions{namespace: "default", trustedProxyHops: 0, rateLimit: 30, rateBurst: 10}
+
+	tests := []struct {
+		name    string
+		mutate  func(*webOptions)
+		wantErr error
+	}{
+		{name: "defaults are accepted", mutate: func(*webOptions) {}},
+		{name: "one proxy in front", mutate: func(o *webOptions) { o.trustedProxyHops = 1 }},
+		// Reads as "trust one hop" but would disable proxy headers instead.
+		{
+			name:    "negative hops are refused",
+			mutate:  func(o *webOptions) { o.trustedProxyHops = -1 },
+			wantErr: errNegativeProxyHops,
+		},
+		// Zero rate or burst never refills and never lets anything through, so
+		// every request answers 429 with nothing in the log to explain it.
+		{
+			name:    "zero rate limit is refused",
+			mutate:  func(o *webOptions) { o.rateLimit = 0 },
+			wantErr: errRateLimitInvalid,
+		},
+		{
+			name:    "negative rate limit is refused",
+			mutate:  func(o *webOptions) { o.rateLimit = -1 },
+			wantErr: errRateLimitInvalid,
+		},
+		// NaN is the one input that fails open: it passes every ordered
+		// comparison, so a bare "<= 0" check lets it through, and the limiter
+		// then allows every request.
+		{
+			name:    "NaN rate limit is refused",
+			mutate:  func(o *webOptions) { o.rateLimit = math.NaN() },
+			wantErr: errRateLimitInvalid,
+		},
+		{
+			name:    "positive infinity is refused",
+			mutate:  func(o *webOptions) { o.rateLimit = math.Inf(1) },
+			wantErr: errRateLimitInvalid,
+		},
+		{
+			name:    "negative infinity is refused",
+			mutate:  func(o *webOptions) { o.rateLimit = math.Inf(-1) },
+			wantErr: errRateLimitInvalid,
+		},
+		{
+			name:    "zero burst is refused",
+			mutate:  func(o *webOptions) { o.rateBurst = 0 },
+			wantErr: errRateBurstTooLow,
+		},
+		{
+			name:    "negative burst is refused",
+			mutate:  func(o *webOptions) { o.rateBurst = -1 },
+			wantErr: errRateBurstTooLow,
+		},
+		// An empty namespace is cluster-wide on list, not a narrower scope, so
+		// the public page would serve every Wish in the cluster.
+		{
+			name:    "empty namespace is refused",
+			mutate:  func(o *webOptions) { o.namespace = "" },
+			wantErr: errEmptyNamespace,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := valid
+			tt.mutate(&opts)
+
+			err := validateWebFlags(&opts)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestBindWebFlags_RateLimitUnitIsSeconds guards the help text against drifting
+// back to "per minute": rate.Limit is events per second, so the wrong unit is a
+// 60x error for anyone tuning the limiter from the flag description.
+func TestBindWebFlags_RateLimitUnitIsSeconds(t *testing.T) {
+	t.Parallel()
+
+	flagSet, _ := newWebFlagSet(t)
+
+	usage := flagSet.Lookup("rate-limit").Usage
+	assert.Contains(t, usage, "per second")
+	assert.NotContains(t, usage, "per minute")
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.5
 
 require (
 	github.com/a-h/templ v0.3.1020
+	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
 	github.com/stretchr/testify v1.11.1
@@ -27,7 +28,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.22.4 // indirect

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -6,8 +6,10 @@ package web
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
+	"net/netip"
 	"slices"
 	"sort"
 	"strconv"
@@ -29,7 +31,31 @@ const (
 	minWeeks       = 1
 	maxWeeks       = 8
 	maxRequestBody = 1 << 20 // 1 MB
+
+	// limiterSweepInterval bounds how often idle limiter entries are swept, so
+	// the hot path stays cheap under load.
+	limiterSweepInterval = 10 * time.Minute
+	// limiterIdleTTL is how long a limiter may sit untouched before eviction.
+	limiterIdleTTL = time.Hour
+	// limiterMaxEntries caps the map so its size is bounded by more than time.
+	// The idle TTL alone lets the map hold every address seen in the last hour,
+	// and a directly reachable server sees whatever addresses reach it.
+	limiterMaxEntries = 10000
+	// limiterEvictTarget is the size a size-triggered eviction trims down to,
+	// so the ordering pass is amortised over many requests instead of running
+	// once per insert while the map sits at the cap.
+	limiterEvictTarget = limiterMaxEntries * 9 / 10
+	// ipv6BucketBits is the prefix length IPv6 limiter keys are bucketed to.
+	// A /64 is the smallest block a single subscriber is normally assigned.
+	ipv6BucketBits = 64
 )
+
+// limiterEntry pairs a per-IP limiter with the last time it was accessed, so
+// idle entries can be evicted instead of growing the map without bound.
+type limiterEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
 
 // Server handles HTTP requests for the wishlist web interface.
 type Server struct {
@@ -37,16 +63,39 @@ type Server struct {
 	namespace string
 	rateLimit float64
 	rateBurst int
-	limiters  sync.Map
+
+	// trustedProxyHops is how many proxies append to X-Forwarded-For in front
+	// of this server. Zero means proxy headers are ignored entirely.
+	trustedProxyHops int
+
+	// now is the injectable time source, overridden in tests for deterministic
+	// eviction behaviour.
+	now func() time.Time
+
+	limitersMu sync.Mutex
+	limiters   map[string]*limiterEntry
+	lastSweep  time.Time
 }
 
-// NewServer creates a new web server.
-func NewServer(c client.Client, namespace string, rateLimit float64, rateBurst int) *Server {
+// NewServer creates a new web server. trustedProxyHops declares how many
+// proxies in front of this server append to X-Forwarded-For; use 0 when the
+// server is reachable directly, so that client-supplied proxy headers are
+// ignored.
+func NewServer(
+	c client.Client,
+	namespace string,
+	trustedProxyHops int,
+	rateLimit float64,
+	rateBurst int,
+) *Server {
 	return &Server{
-		client:    c,
-		namespace: namespace,
-		rateLimit: rateLimit,
-		rateBurst: rateBurst,
+		client:           c,
+		namespace:        namespace,
+		trustedProxyHops: trustedProxyHops,
+		rateLimit:        rateLimit,
+		rateBurst:        rateBurst,
+		now:              time.Now,
+		limiters:         make(map[string]*limiterEntry),
 	}
 }
 
@@ -265,38 +314,200 @@ func (s *Server) rateLimitMiddleware(next http.Handler) http.Handler {
 }
 
 func (s *Server) getLimiter(ip string) *rate.Limiter {
-	if v, ok := s.limiters.Load(ip); ok {
-		limiter, isLimiter := v.(*rate.Limiter)
-		if isLimiter {
-			return limiter
+	s.limitersMu.Lock()
+	defer s.limitersMu.Unlock()
+
+	now := s.now()
+
+	entry, ok := s.limiters[ip]
+	if ok {
+		entry.lastSeen = now
+	} else {
+		entry = &limiterEntry{
+			limiter:  rate.NewLimiter(rate.Limit(s.rateLimit), s.rateBurst),
+			lastSeen: now,
 		}
+		s.limiters[ip] = entry
 	}
 
-	limiter := rate.NewLimiter(rate.Limit(s.rateLimit), s.rateBurst)
-	s.limiters.Store(ip, limiter)
+	// Sweep after touching this entry so the active caller always survives.
+	s.sweepLocked(now)
+	s.enforceCapLocked(now, ip)
 
-	return limiter
+	return entry.limiter
+}
+
+// sweepLocked evicts limiter entries idle longer than limiterIdleTTL. It runs at
+// most once per limiterSweepInterval to keep the request path cheap. The caller
+// must hold limitersMu.
+func (s *Server) sweepLocked(now time.Time) {
+	if now.Sub(s.lastSweep) < limiterSweepInterval {
+		return
+	}
+
+	s.lastSweep = now
+
+	s.evictIdleLocked(now)
+}
+
+// evictIdleLocked drops every entry past the idle TTL. The caller must hold
+// limitersMu.
+func (s *Server) evictIdleLocked(now time.Time) {
+	for ip, entry := range s.limiters {
+		if now.Sub(entry.lastSeen) > limiterIdleTTL {
+			delete(s.limiters, ip)
+		}
+	}
+}
+
+// enforceCapLocked keeps the map under limiterMaxEntries regardless of how much
+// time has passed, because the interval gate spreads the sweep cost over time
+// without bounding it: between two sweeps the map grows once per new address.
+// keep is the entry being served right now, which is never evicted: dropping it
+// would hand its caller a limiter that is no longer in the map, so the next
+// request would mint a fresh one with a full burst. The caller must hold
+// limitersMu.
+func (s *Server) enforceCapLocked(now time.Time, keep string) {
+	if len(s.limiters) <= limiterMaxEntries {
+		return
+	}
+
+	// A sweep may not have been due yet, so try the cheap pass first.
+	s.evictIdleLocked(now)
+
+	if len(s.limiters) <= limiterMaxEntries {
+		return
+	}
+
+	// Still over: drop the least recently seen down to the target, so the
+	// ordering pass is amortised instead of running once per insert. Ordering
+	// alone cannot protect the served entry, because the sort is not stable and
+	// timestamps tie whenever the clock is coarser than the arrival rate.
+	ips := slices.SortedFunc(maps.Keys(s.limiters), func(a, b string) int {
+		return s.limiters[a].lastSeen.Compare(s.limiters[b].lastSeen)
+	})
+
+	for _, ip := range ips {
+		if len(s.limiters) <= limiterEvictTarget {
+			break
+		}
+
+		if ip == keep {
+			continue
+		}
+
+		delete(s.limiters, ip)
+	}
 }
 
 func (s *Server) getClientIP(r *http.Request) string {
-	// Check X-Forwarded-For header
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		ips := strings.Split(xff, ",")
-		if len(ips) > 0 {
-			return strings.TrimSpace(ips[0])
+	// Proxy headers only mean something when a known number of proxies sits in
+	// front. Each appends the address it received the request from, so counting
+	// from the right is the only way to reach an entry no client could write:
+	// everything further left is copied verbatim from what the caller sent.
+	// With no declared hops the whole header is client-controlled, so it is
+	// ignored and the connection address decides.
+	if s.trustedProxyHops > 0 {
+		// Some proxies add their own X-Forwarded-For line instead of extending
+		// the existing one. Both forms carry the same list, so join every line
+		// before counting: reading only the first one would count entries in
+		// whatever the caller sent and ignore what the proxy wrote.
+		//
+		// What this needs from the proxy in front: that it appends its view of
+		// the downstream address at the END of the list, whether by extending
+		// the last line or adding a new one. nginx, Envoy, HAProxy, Traefik and
+		// Cloudflare all do. A proxy that prepends instead, or that passes the
+		// header through untouched, breaks the count and must be declared as
+		// zero hops.
+		xff := strings.Join(r.Header.Values("X-Forwarded-For"), ",")
+		if ip := trustedForwardedFor(xff, s.trustedProxyHops); ip != "" {
+			return ip
 		}
 	}
 
-	// Check X-Real-IP header
-	if xri := r.Header.Get("X-Real-IP"); xri != "" {
-		return xri
-	}
-
-	// Fall back to RemoteAddr
+	// Declared hops that produced nothing usable mean the request did not come
+	// through the chain the operator described, so no header is worth reading:
+	// X-Real-IP in particular is passed through untouched by proxies that only
+	// append to X-Forwarded-For, and honouring it would let a caller pick its
+	// own limiter bucket by sending a malformed X-Forwarded-For alongside it.
+	// The connection address goes through the same normalisation as a header
+	// entry. This is the path the default configuration takes for every
+	// request, so it is where the IPv6 bucketing matters most.
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		return r.RemoteAddr
 	}
 
+	if key := parseIPEntry(host); key != "" {
+		return key
+	}
+
 	return host
+}
+
+// trustedForwardedFor returns the X-Forwarded-For entry written by the outermost
+// trusted proxy. It returns an empty string when the chain is shorter than the
+// declared hop count, which means the remaining entries came from the client.
+func trustedForwardedFor(xff string, hops int) string {
+	if xff == "" {
+		return ""
+	}
+
+	// Walk right to left rather than splitting the whole header. This runs on
+	// caller-supplied input before the rate limiter does anything, so a header
+	// full of commas must not turn into one allocation per entry.
+	end := len(xff)
+
+	for range hops - 1 {
+		comma := strings.LastIndexByte(xff[:end], ',')
+		if comma < 0 {
+			return ""
+		}
+
+		end = comma
+	}
+
+	start := strings.LastIndexByte(xff[:end], ',') + 1
+
+	return parseIPEntry(xff[start:end])
+}
+
+// parseIPEntry returns value as a bare IP address, or an empty string if it is
+// not one. Limiter keys must never be arbitrary caller-supplied text: every
+// distinct key mints a limiter with a full burst, so unvalidated keys hand a
+// caller both an unbounded map and a way around the limit.
+// The key is canonical, so that a proxy writing 2001:0db8::1 on one request and
+// 2001:db8::1 on the next does not split one client across two buckets.
+func parseIPEntry(value string) string {
+	value = strings.TrimSpace(value)
+
+	addr, err := netip.ParseAddr(value)
+	if err != nil {
+		// Some proxies append host:port rather than a bare address.
+		addrPort, portErr := netip.ParseAddrPort(value)
+		if portErr != nil {
+			return ""
+		}
+
+		addr = addrPort.Addr()
+	}
+
+	return limiterKey(addr)
+}
+
+// limiterKey buckets IPv6 by prefix instead of by address. A single subscriber
+// is handed a whole /64, so keying on the address would hand out a fresh
+// limiter, with a fresh burst, for every request — the same bypass a forged
+// header used to give, reached by rotating addresses instead. IPv4 addresses
+// are scarce enough to key individually.
+func limiterKey(addr netip.Addr) string {
+	addr = addr.Unmap().WithZone("")
+
+	if !addr.Is4() {
+		if prefix, err := addr.Prefix(ipv6BucketBits); err == nil {
+			return prefix.String()
+		}
+	}
+
+	return addr.String()
 }

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -8,7 +8,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,6 +23,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	wishlistv1alpha1 "github.com/lexfrei/wish-operator/api/v1alpha1"
+
+	"golang.org/x/time/rate"
 )
 
 // Shared test fixtures to avoid duplicated string literals.
@@ -31,9 +36,29 @@ const (
 	testUnlimitedName      = "unlimited-test"
 	testUnlimitedMultiName = "unlimited-test-multi"
 	testTitleUnlimited     = "Unlimited Item"
+	testProxyHost          = "10.0.0.1"
+	testProxyRemoteAddr    = testProxyHost + ":5000"
+	testActiveIP           = "203.0.113.1"
+	testRealIP             = "203.0.113.9"
+	testProxyAppendedIP    = "203.0.113.7"
+	testXFFNonIPEntry      = "1.1.1.1, notanip"
+	testXFFEmptyEntry      = "1.1.1.1, "
+	testIPv6Bucket         = "2001:db8::/64"
+	testDirectIP           = "203.0.113.10"
+	testDirectRemoteAddr   = testDirectIP + ":5000"
+	testUnsplittableAddr   = "not-a-host-port"
 )
 
+// newTestServer builds a server with the shipped default hop count, so tests
+// that do not care about proxies exercise the configuration the chart produces.
+// Proxy behaviour opts in through newTestServerWithHops.
 func newTestServer(t *testing.T, wishes ...*wishlistv1alpha1.Wish) *Server {
+	t.Helper()
+
+	return newTestServerWithHops(t, 0, wishes...)
+}
+
+func newTestServerWithHops(t *testing.T, hops int, wishes ...*wishlistv1alpha1.Wish) *Server {
 	t.Helper()
 
 	scheme := runtime.NewScheme()
@@ -51,7 +76,7 @@ func newTestServer(t *testing.T, wishes ...*wishlistv1alpha1.Wish) *Server {
 		WithStatusSubresource(objs...).
 		Build()
 
-	return NewServer(fakeClient, testNamespace, 30, 10)
+	return NewServer(fakeClient, testNamespace, hops, 30, 10)
 }
 
 func TestServer_HandleIndex(t *testing.T) {
@@ -346,6 +371,80 @@ func TestServer_RateLimiting(t *testing.T) {
 	assert.Equal(t, http.StatusTooManyRequests, rec3.Code)
 }
 
+// TestServer_RateLimitingBehindProxy exercises the contract through the real
+// handler chain: two visitors arriving via the same proxy must get their own
+// budget, and a caller rotating forged entries must not escape the one it
+// already spent.
+func TestServer_RateLimitingBehindProxy(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServerWithHops(t, 1)
+	srv.rateLimit = 1
+	srv.rateBurst = 1
+
+	handler := srv.Handler()
+
+	get := func(xff []string) int {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, newProxiedRequest(xff, testRealIP, testProxyRemoteAddr))
+
+		return rec.Code
+	}
+
+	// The forger spends its single token.
+	assert.Equal(t, http.StatusOK, get([]string{"1.1.1.1, " + testProxyAppendedIP}))
+
+	// Rotating the caller-controlled prefixes, and moving the forged entry onto
+	// its own header line, must land on the same exhausted bucket.
+	assert.Equal(t, http.StatusTooManyRequests, get([]string{"2.2.2.2, 3.3.3.3, " + testProxyAppendedIP}))
+	assert.Equal(t, http.StatusTooManyRequests, get([]string{"4.4.4.4", testProxyAppendedIP}))
+
+	// An unrelated visitor behind the same proxy still has its own budget.
+	assert.Equal(t, http.StatusOK, get([]string{"1.1.1.1, " + testActiveIP}))
+}
+
+// TestServer_RotatingHeaderExhaustsOneBudget pins the measured before-state:
+// with the old first-entry rule, 5000 requests each carrying a different
+// X-Forwarded-For value were all allowed and left 5000 limiters behind. Whether
+// the header is trusted or ignored, they must now land in one bucket.
+func TestServer_RotatingHeaderExhaustsOneBudget(t *testing.T) {
+	t.Parallel()
+
+	const rotations = 5000
+
+	for _, hops := range []int{0, 1} {
+		t.Run("hops="+strconv.Itoa(hops), func(t *testing.T) {
+			t.Parallel()
+
+			srv := newTestServerWithHops(t, hops)
+			srv.rateLimit = 1
+			srv.rateBurst = 1
+
+			handler := srv.Handler()
+
+			allowed := 0
+
+			for i := range rotations {
+				// Distinct forged prefixes, one appended entry, as a proxy
+				// would leave it.
+				xff := []string{"198.51.100." + strconv.Itoa(i%256) + ", " + testProxyAppendedIP}
+
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, newProxiedRequest(xff, testRealIP, testProxyRemoteAddr))
+
+				if rec.Code == http.StatusOK {
+					allowed++
+				}
+			}
+
+			// One bucket refilling at 1/s: the loop is far too short to earn
+			// more than a handful of tokens, and nowhere near 5000.
+			assert.Less(t, allowed, 10, "a rotating header must not buy extra budget")
+			assert.Len(t, srv.limiters, 1, "a rotating header must not mint limiters")
+		})
+	}
+}
+
 func TestServer_HandleReserve_Unlimited(t *testing.T) {
 	t.Parallel()
 
@@ -442,4 +541,558 @@ func TestServer_HandleReserve_UnlimitedMultiple(t *testing.T) {
 	assert.Len(t, final.Status.Reservations, 2)
 	assert.Equal(t, int32(50), final.Status.Reservations[0].Quantity)
 	assert.Equal(t, int32(75), final.Status.Reservations[1].Quantity)
+}
+
+// newProxiedRequest builds a request carrying one X-Forwarded-For line per
+// entry of xff, so tests can cover proxies that add a second line rather than
+// extending the first.
+func newProxiedRequest(xff []string, xRealIP, remoteAddr string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = remoteAddr
+
+	for _, line := range xff {
+		req.Header.Add("X-Forwarded-For", line)
+	}
+
+	if xRealIP != "" {
+		req.Header.Set("X-Real-IP", xRealIP)
+	}
+
+	return req
+}
+
+func TestServer_GetClientIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		hops       int
+		xff        []string
+		xRealIP    string
+		remoteAddr string
+		want       string
+	}{
+		{
+			// Nothing declared in front means the whole header came from the
+			// caller, so honouring it would hand out a bucket per request.
+			name:       "undeclared proxy ignores X-Forwarded-For",
+			hops:       0,
+			xff:        []string{testProxyAppendedIP},
+			remoteAddr: testProxyRemoteAddr,
+			want:       testProxyHost,
+		},
+		{
+			// A proxy that adds its own line rather than extending the caller's
+			// carries the same list; reading only the first line would count
+			// entries in what the caller sent.
+			name:       "proxy line added after the caller's line is used",
+			hops:       1,
+			xff:        []string{"1.1.1.1", testProxyAppendedIP},
+			remoteAddr: testProxyRemoteAddr,
+			want:       testProxyAppendedIP,
+		},
+		{
+			name:       "entries are counted across all header lines",
+			hops:       2,
+			xff:        []string{"1.1.1.1, " + testProxyAppendedIP, "198.51.100.5"},
+			remoteAddr: testProxyRemoteAddr,
+			want:       testProxyAppendedIP,
+		},
+		{
+			// Proxies that append to X-Forwarded-For pass X-Real-IP through
+			// untouched, so it is caller-controlled at any hop count.
+			name:       "X-Real-IP is never trusted",
+			hops:       1,
+			xRealIP:    testRealIP,
+			remoteAddr: testProxyRemoteAddr,
+			want:       testProxyHost,
+		},
+		{
+			name:       "X-Real-IP cannot override a rejected X-Forwarded-For",
+			hops:       1,
+			xff:        []string{testXFFNonIPEntry},
+			xRealIP:    testRealIP,
+			remoteAddr: testProxyRemoteAddr,
+			want:       testProxyHost,
+		},
+		{
+			// A caller rotating fake values only controls the entries to the
+			// left of the one the proxy appended.
+			name:       "one hop takes the entry the proxy appended",
+			hops:       1,
+			xff:        []string{"1.1.1.1, 2.2.2.2, " + testProxyAppendedIP},
+			remoteAddr: testProxyRemoteAddr,
+			want:       testProxyAppendedIP,
+		},
+		{
+			name:       "surrounding whitespace is trimmed",
+			hops:       1,
+			xff:        []string{"  " + testProxyAppendedIP + "  "},
+			remoteAddr: testProxyRemoteAddr,
+			want:       testProxyAppendedIP,
+		},
+		{
+			name:       "appended host:port keeps the host",
+			hops:       1,
+			xff:        []string{"1.1.1.1, " + testProxyAppendedIP + ":41000"},
+			remoteAddr: testProxyRemoteAddr,
+			want:       testProxyAppendedIP,
+		},
+		{
+			// A single subscriber holds a whole /64, so the bucket is the
+			// prefix: keying on the address would hand out a fresh burst for
+			// every address the caller cares to use.
+			name:       "IPv6 entry is bucketed by prefix",
+			hops:       1,
+			xff:        []string{"1.1.1.1, 2001:db8::1"},
+			remoteAddr: testProxyRemoteAddr,
+			want:       testIPv6Bucket,
+		},
+		{
+			// Two spellings of one address must not become two buckets.
+			name:       "IPv6 entry is canonicalised",
+			hops:       1,
+			xff:        []string{"1.1.1.1, 2001:0DB8:0000:0000:0000:0000:0000:0001"},
+			remoteAddr: testProxyRemoteAddr,
+			want:       testIPv6Bucket,
+		},
+		{
+			name:       "a different IPv6 prefix is a different bucket",
+			hops:       1,
+			xff:        []string{"1.1.1.1, 2001:db8:0:1::1"},
+			remoteAddr: testProxyRemoteAddr,
+			want:       "2001:db8:0:1::/64",
+		},
+		{
+			// IPv4 stays per-address; the scarcity argument for bucketing does
+			// not apply.
+			name:       "IPv4 connection address is not bucketed",
+			hops:       0,
+			remoteAddr: testDirectRemoteAddr,
+			want:       testDirectIP,
+		},
+		{
+			name:       "IPv6 connection address is bucketed too",
+			hops:       0,
+			remoteAddr: "[2001:db8::dead:beef]:5000",
+			want:       testIPv6Bucket,
+		},
+		{
+			// A 4-in-6 mapped address is the IPv4 address, not a v6 prefix.
+			name:       "IPv4-mapped IPv6 is treated as IPv4",
+			hops:       1,
+			xff:        []string{"1.1.1.1, ::ffff:203.0.113.7"},
+			remoteAddr: testProxyRemoteAddr,
+			want:       testProxyAppendedIP,
+		},
+		{
+			// Anything that is not an address would become a limiter key of the
+			// caller's choosing.
+			name:       "non-IP entry is rejected",
+			hops:       1,
+			xff:        []string{testXFFNonIPEntry},
+			remoteAddr: testProxyRemoteAddr,
+			want:       testProxyHost,
+		},
+		{
+			name:       "empty trailing entry is rejected",
+			hops:       1,
+			xff:        []string{testXFFEmptyEntry},
+			remoteAddr: testProxyRemoteAddr,
+			want:       testProxyHost,
+		},
+		{
+			// net/http always sets host:port, so this is unreachable in
+			// production. Pinned because it is the only key that does not go
+			// through parseIPEntry, and the address comes from the connection
+			// rather than from anything the caller wrote.
+			name:       "unsplittable RemoteAddr is used as-is",
+			hops:       1,
+			remoteAddr: testUnsplittableAddr,
+			want:       testUnsplittableAddr,
+		},
+		{
+			// Also unreachable through net/http, which hands over a numeric
+			// address, but it is the one key that skips address parsing and so
+			// worth pinning next to its sibling above.
+			name:       "non-numeric RemoteAddr host is used as-is",
+			hops:       1,
+			remoteAddr: "wish.example:8080",
+			want:       "wish.example",
+		},
+		{
+			name:       "no proxy headers falls back to RemoteAddr host",
+			hops:       1,
+			remoteAddr: testDirectRemoteAddr,
+			want:       testDirectIP,
+		},
+		{
+			// With two appending proxies the rightmost entry is the inner
+			// proxy's own address, identical for every visitor.
+			name:       "two hops skip the inner proxy address",
+			hops:       2,
+			xff:        []string{"1.1.1.1, " + testProxyAppendedIP + ", 198.51.100.5"},
+			remoteAddr: testProxyRemoteAddr,
+			want:       testProxyAppendedIP,
+		},
+		{
+			// Fewer entries than declared hops means the chain is not what the
+			// operator described, so what is left is caller-supplied.
+			name:       "chain shorter than the declared hops falls back",
+			hops:       2,
+			xff:        []string{testProxyAppendedIP},
+			remoteAddr: testProxyRemoteAddr,
+			want:       testProxyHost,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := newTestServerWithHops(t, tt.hops)
+			req := newProxiedRequest(tt.xff, tt.xRealIP, tt.remoteAddr)
+
+			assert.Equal(t, tt.want, srv.getClientIP(req))
+		})
+	}
+}
+
+// TestServer_ForgedProxyHeadersShareOneLimiter pins the property the whole
+// change exists for: a caller rotating proxy headers must not mint a limiter
+// per value, because each new limiter arrives with a fresh burst and the map
+// keeps it for an hour.
+func TestServer_ForgedProxyHeadersShareOneLimiter(t *testing.T) {
+	t.Parallel()
+
+	rotatingPrefixes := [][]string{
+		{"1.1.1.1, " + testProxyAppendedIP},
+		{"9.9.9.9, 8.8.8.8, " + testProxyAppendedIP},
+		// A caller line the proxy left alone before adding its own.
+		{"9.9.9.9", testProxyAppendedIP},
+	}
+
+	unparsable := [][]string{
+		{testXFFNonIPEntry},
+		{"1.1.1.1, <script>"},
+		{"1.1.1.1, " + strings.Repeat("a", 64)},
+		{testXFFEmptyEntry},
+		nil,
+	}
+
+	fill := func(srv *Server, headers [][]string) {
+		for _, xff := range headers {
+			// A caller-supplied X-Real-IP rides along on every request.
+			srv.getLimiter(srv.getClientIP(newProxiedRequest(xff, testRealIP, testProxyRemoteAddr)))
+		}
+	}
+
+	tests := []struct {
+		name    string
+		hops    int
+		headers [][]string
+		wantKey string
+	}{
+		{
+			name:    "rotating prefixes reach one limiter",
+			hops:    1,
+			headers: rotatingPrefixes,
+			wantKey: testProxyAppendedIP,
+		},
+		{
+			name:    "unparsable entries collapse onto the connection address",
+			hops:    1,
+			headers: unparsable,
+			wantKey: testProxyHost,
+		},
+		{
+			name:    "undeclared proxy ignores every header",
+			hops:    0,
+			headers: slices.Concat(rotatingPrefixes, unparsable),
+			wantKey: testProxyHost,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := newTestServerWithHops(t, tt.hops)
+			fill(srv, tt.headers)
+
+			assert.Len(t, srv.limiters, 1, "forged headers must not mint extra limiters")
+			assert.Contains(t, srv.limiters, tt.wantKey)
+		})
+	}
+}
+
+// TestServer_IPv6AddressesShareAPrefixBucket pins the v6 half of the same
+// property the header rules buy: a caller holding a /64 must not get a fresh
+// limiter, and a fresh burst, per address it picks out of it.
+func TestServer_IPv6AddressesShareAPrefixBucket(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t)
+
+	limiterFor := func(addr string) *rate.Limiter {
+		req := newProxiedRequest(nil, "", addr)
+
+		return srv.getLimiter(srv.getClientIP(req))
+	}
+
+	first := limiterFor("[2001:db8::1]:5000")
+	second := limiterFor("[2001:db8::dead:beef]:41000")
+	other := limiterFor("[2001:db8:0:1::1]:5000")
+
+	assert.Same(t, first, second, "addresses in one /64 must share a limiter")
+	assert.NotSame(t, first, other, "a different /64 must get its own limiter")
+	assert.Len(t, srv.limiters, 2)
+}
+
+func TestServer_GetLimiterIsConcurrencySafe(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t)
+
+	const (
+		callers   = 64
+		distinct  = 4
+		wantEntry = "203.0.113."
+	)
+
+	var wg sync.WaitGroup
+
+	limiters := make([]*rate.Limiter, callers)
+
+	for i := range callers {
+		wg.Go(func() {
+			limiters[i] = srv.getLimiter(wantEntry + strconv.Itoa(i%distinct))
+		})
+	}
+
+	wg.Wait()
+
+	assert.Len(t, srv.limiters, distinct)
+
+	for i, limiter := range limiters {
+		require.NotNil(t, limiter)
+		assert.Same(t, limiters[i%distinct], limiter, "one limiter per key")
+	}
+}
+
+func TestServer_LimiterEviction(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t)
+
+	base := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	current := base
+	srv.now = func() time.Time { return current }
+
+	// Populate limiters for three distinct IPs at the base time.
+	srv.getLimiter(testActiveIP)
+	srv.getLimiter("203.0.113.2")
+	srv.getLimiter("203.0.113.3")
+
+	require.Len(t, srv.limiters, 3)
+
+	// Advance past both the sweep interval and the idle TTL.
+	current = base.Add(limiterIdleTTL + limiterSweepInterval + time.Minute)
+
+	// A request from one IP refreshes it, then triggers the inline sweep that
+	// evicts the two now-idle entries.
+	srv.getLimiter(testActiveIP)
+
+	require.Len(t, srv.limiters, 1)
+	_, ok := srv.limiters[testActiveIP]
+	assert.True(t, ok, "active IP must survive the sweep")
+}
+
+// TestServer_LimiterSweepIsThrottled pins the interval gate. The sweep walks the
+// whole map under the lock, so running it on every request is what the gate
+// exists to prevent; without it the O(n) scan lands on every caller.
+func TestServer_LimiterSweepIsThrottled(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t)
+
+	base := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	current := base
+	srv.now = func() time.Time { return current }
+
+	// The first call always sweeps, which is what sets the clock for the gate.
+	srv.getLimiter(testActiveIP)
+	require.Equal(t, base, srv.lastSweep)
+
+	// Idle entries only ever outlive the TTL by up to one interval, so the gate
+	// cannot be observed by an entry that survives; what it controls is how
+	// often the map is walked under the lock.
+	current = base.Add(limiterSweepInterval - time.Minute)
+	srv.getLimiter(testActiveIP)
+	assert.Equal(t, base, srv.lastSweep, "sweep must not run again inside the interval")
+
+	current = base.Add(limiterSweepInterval + time.Minute)
+	srv.getLimiter(testActiveIP)
+	assert.Equal(t, current, srv.lastSweep, "sweep must run once the interval has passed")
+}
+
+// TestServer_LimiterSurvivesBelowIdleTTL pins the other side of the boundary:
+// an entry idle for slightly less than the TTL is still in use as far as the
+// limiter is concerned and must keep its accumulated tokens.
+func TestServer_LimiterSurvivesBelowIdleTTL(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t)
+
+	base := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	current := base
+	srv.now = func() time.Time { return current }
+
+	srv.getLimiter(testActiveIP)
+	idle := srv.getLimiter("203.0.113.2")
+
+	// Past the sweep interval so a sweep happens, but short of the idle TTL.
+	current = base.Add(limiterIdleTTL - time.Minute)
+	srv.getLimiter(testActiveIP)
+
+	require.Len(t, srv.limiters, 2)
+	assert.Same(t, idle, srv.getLimiter("203.0.113.2"), "entry below the idle TTL keeps its limiter")
+}
+
+// TestServer_LimiterMapIsCapped pins the size bound. The idle TTL only bounds
+// the map in time: between two sweeps it grows once per distinct address, and
+// nothing about being under the TTL makes an entry worth keeping when there are
+// already more of them than the process should hold.
+func TestServer_LimiterMapIsCapped(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t)
+
+	base := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	current := base
+	srv.now = func() time.Time { return current }
+
+	const overflow = 500
+
+	// Every key is fresh and the whole loop stays well inside one sweep
+	// interval, so the idle sweep can never fire: only the cap can bound this.
+	var lastKey string
+
+	for i := range limiterMaxEntries + overflow {
+		current = base.Add(time.Duration(i) * time.Millisecond)
+		lastKey = "key-" + strconv.Itoa(i)
+
+		srv.getLimiter(lastKey)
+	}
+
+	require.Equal(t, base, srv.lastSweep, "lastSweep must be unchanged since the first call")
+	assert.LessOrEqual(t, len(srv.limiters), limiterMaxEntries)
+	assert.Contains(t, srv.limiters, lastKey)
+}
+
+// TestServer_LimiterCapPrefersIdleEviction pins the cheap path the cap takes
+// first: when dropping idle entries alone brings the map back under the cap, no
+// ordering pass runs and nothing still in use is touched. Without it the cap
+// would trim by age even when every evictable entry was already stale.
+func TestServer_LimiterCapPrefersIdleEviction(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t)
+
+	now := time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC)
+	srv.now = func() time.Time { return now }
+
+	// A sweep happened a minute ago, so the interval gate holds the scheduled
+	// one back and only the cap can act. Without that the sweep would clear the
+	// map first and this path would never be reached.
+	srv.lastSweep = now.Add(-time.Minute)
+
+	idle := make([]string, 0, limiterMaxEntries+1)
+
+	for i := range limiterMaxEntries + 1 {
+		key := "idle-" + strconv.Itoa(i)
+		idle = append(idle, key)
+		srv.limiters[key] = &limiterEntry{
+			limiter:  rate.NewLimiter(1, 1),
+			lastSeen: now.Add(-2 * limiterIdleTTL),
+		}
+	}
+
+	fresh := "fresh"
+	srv.limiters[fresh] = &limiterEntry{limiter: rate.NewLimiter(1, 1), lastSeen: now}
+
+	srv.getLimiter(testActiveIP)
+
+	assert.LessOrEqual(t, len(srv.limiters), limiterMaxEntries)
+	// The survivors are exactly the entries that were not idle, which is what
+	// separates idle eviction from a plain trim of the oldest.
+	assert.Contains(t, srv.limiters, fresh)
+	assert.Contains(t, srv.limiters, testActiveIP)
+
+	for _, key := range idle {
+		require.NotContains(t, srv.limiters, key)
+	}
+}
+
+// TestServer_LimiterCapKeepsTheServedEntry pins that eviction never drops the
+// caller it is currently serving. Ordering alone does not guarantee it: the
+// sort is not stable and timestamps tie whenever the clock is coarser than the
+// arrival rate. An evicted caller is handed a limiter that is no longer in the
+// map, so its next request mints a fresh one with a full burst — the bypass
+// this change exists to close, reached through cap pressure instead of header
+// rotation.
+func TestServer_LimiterCapKeepsTheServedEntry(t *testing.T) {
+	t.Parallel()
+
+	frozen := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	// Make the served entry strictly the oldest, so the ordering puts it first
+	// in line for eviction and only the guard can save it. Ties would leave the
+	// outcome to map iteration order, which is randomised — a test that only
+	// catches the bug some of the time is not a test.
+	t.Run("survives being the oldest entry", func(t *testing.T) {
+		t.Parallel()
+
+		srv := newTestServer(t)
+		srv.now = func() time.Time { return frozen }
+
+		const served = "served"
+
+		for i := range limiterMaxEntries + 1 {
+			srv.limiters["key-"+strconv.Itoa(i)] = &limiterEntry{
+				limiter:  rate.NewLimiter(1, 1),
+				lastSeen: frozen.Add(time.Second),
+			}
+		}
+
+		srv.limiters[served] = &limiterEntry{limiter: rate.NewLimiter(1, 1), lastSeen: frozen}
+
+		srv.enforceCapLocked(frozen, served)
+
+		assert.Contains(t, srv.limiters, served, "the entry being served must never be evicted")
+		// Trimming to the target rather than to the cap is what amortises the
+		// ordering pass; stopping at the cap would re-sort on every insert.
+		assert.Len(t, srv.limiters, limiterEvictTarget)
+	})
+
+	// The realistic shape: a clock coarser than the arrival rate ties every
+	// timestamp, so eviction order among them is arbitrary.
+	t.Run("survives a tie across every entry", func(t *testing.T) {
+		t.Parallel()
+
+		srv := newTestServer(t)
+		srv.now = func() time.Time { return frozen }
+
+		for i := range limiterMaxEntries + 500 {
+			key := "key-" + strconv.Itoa(i)
+
+			limiter := srv.getLimiter(key)
+
+			entry, ok := srv.limiters[key]
+			require.True(t, ok, "served key %s was evicted while being served", key)
+			require.Same(t, limiter, entry.limiter, "served key %s must map to the limiter handed out", key)
+		}
+
+		assert.LessOrEqual(t, len(srv.limiters), limiterMaxEntries)
+	})
 }


### PR DESCRIPTION
The per-IP rate limiter keyed off the first X-Forwarded-For entry, which is copied verbatim from whatever the caller sent, so rotating fake values handed out a fresh limiter with a fresh burst on every request and left each one in the map for the lifetime of the process. Which entry can be trusted is a property of the deployment rather than of this code, so it is now declared: `operator.trustedProxyHops` says how many proxies append to the header on the way in, and the client address is read that many entries from the right. The default of 0 ignores the header and uses the connection address, which matches a chart that does not create an HTTPRoute unless asked. Every header line is joined before counting, since some proxies add their own line instead of extending the caller's, and entries have to parse as an IP address, so a limiter key can no longer be arbitrary caller-supplied text. X-Real-IP is not read at all, because proxies that append to X-Forwarded-For pass it through untouched.

Anyone already running behind a proxy has to set the new value during the upgrade, otherwise every visitor shares the bucket belonging to the gateway address, so the README says so where the values are listed and not only in the section that explains the setting.

The map also never released anything. It is now guarded by a mutex, records last access, and sweeps entries idle for over an hour. The sweep runs inline on the request path and at most once per ten minutes, since the server has no shutdown hook and a background goroutine would leak. The clock is injectable so the eviction tests use a fake one instead of sleeping.

Also fixes the rate-limit flag help, which described the value as requests per minute while the limiter has always applied it per second.
