### PR TITLE
fix(web): retry reservation update on conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ spec:
 | `reservations` | List of active reservations (quantity, createdAt, expiresAt) |
 | `conditions` | Declared on the type; the controller does not populate it yet |
 
+### Reservation limits
+
+Reserving is anonymous, so two limits are fixed in the operator rather than exposed as configuration. A wish holds at most 100 live reservations; past that it answers 409 until some expire, and the page stops offering the form. A single reservation claims at most 100 items on a wish with unlimited quantity, where nothing else bounds the request. A wish with a declared quantity is bounded by that quantity instead, however large it is.
+
+These limits keep a wish repairable, not unabusable. What they prevent is the terminal case: an object that grows past what the API server accepts, after which nothing can update it again, including the controller pass that prunes expired reservations. What they do not prevent is one client taking all 100 slots and holding them, because a reservation runs for up to eight weeks and carries no identity at all. The wish then shows "cannot take any more reservations" until they expire, and nothing distinguishes the client that did it from a hundred genuine visitors. Treat the reservation limits as a bound on the damage, not as access control: if a wishlist is public and contested, put it behind something that authenticates.
+
 ## Configuration
 
 ### Helm Values

--- a/api/v1alpha1/crd_manifest_test.go
+++ b/api/v1alpha1/crd_manifest_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025 Aleksei Sviridkin
+
+package v1alpha1_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	wishlistv1alpha1 "github.com/lexfrei/wish-operator/api/v1alpha1"
+)
+
+// manifests are the two copies of the CRD that ship to users. make manifests
+// writes the first; the chart copy is updated by hand, so they drift silently.
+var manifests = []string{
+	filepath.Join("..", "..", "config", "crd", "bases", "wishlist.k8s.lex.la_wishes.yaml"),
+	filepath.Join("..", "..", "charts", "wish-operator", "crds", "wishlist.k8s.lex.la_wishes.yaml"),
+}
+
+// TestCRDQuantityDescription pins what a cluster operator reads from kubectl
+// explain wishes.spec.quantity. The description is generated from a Go doc
+// comment, and the reader has no access to the package it came from: it has
+// to carry the numbers themselves, not the names of the constants holding
+// them.
+func TestCRDQuantityDescription(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range manifests {
+		t.Run(filepath.Base(filepath.Dir(path)), func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := os.ReadFile(path)
+			require.NoError(t, err)
+
+			// The generator wraps long descriptions, so match on the words
+			// rather than on a whole sentence.
+			manifest := strings.Join(strings.Fields(string(raw)), " ")
+
+			// The count limit applies to every wish, so it must not read as a
+			// property of unlimited ones; the per-request limit is the opposite.
+			assert.Contains(t, manifest,
+				fmt.Sprintf("Every wish, whatever its quantity, holds at most %d live reservations",
+					wishlistv1alpha1.MaxReservations))
+			assert.Contains(t, manifest,
+				fmt.Sprintf("on an unlimited wish, where nothing is left to run out, one reservation claims at most %d items",
+					wishlistv1alpha1.MaxQuantityPerRequest))
+			assert.NotContains(t, manifest, "MaxQuantityPerRequest")
+			assert.NotContains(t, manifest, "MaxReservations")
+		})
+	}
+}
+
+// TestREADMEQuotesTheLimits pins the third copy of these numbers. The CRD
+// description and the chart manifest are both checked above; the README says
+// the same thing in prose and nothing else would notice it going stale.
+func TestREADMEQuotesTheLimits(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile(filepath.Join("..", "..", "README.md"))
+	require.NoError(t, err)
+
+	readme := string(raw)
+
+	assert.Contains(t, readme,
+		fmt.Sprintf("at most %d live reservations", wishlistv1alpha1.MaxReservations))
+	assert.Contains(t, readme,
+		fmt.Sprintf("at most %d items on a wish with unlimited quantity",
+			wishlistv1alpha1.MaxQuantityPerRequest))
+	assert.Contains(t, readme,
+		fmt.Sprintf("one client taking all %d slots", wishlistv1alpha1.MaxReservations))
+}
+
+// TestCRDCopiesAreIdentical pins that the chart ships what the generator
+// produced. make manifests only writes config/crd/bases, so the chart copy
+// is one manual step away from being stale.
+func TestCRDCopiesAreIdentical(t *testing.T) {
+	t.Parallel()
+
+	generated, err := os.ReadFile(manifests[0])
+	require.NoError(t, err)
+
+	shipped, err := os.ReadFile(manifests[1])
+	require.NoError(t, err)
+
+	assert.Equal(t, string(generated), string(shipped),
+		"chart CRD is out of sync with config/crd/bases; copy it after make manifests")
+}

--- a/api/v1alpha1/wish_types.go
+++ b/api/v1alpha1/wish_types.go
@@ -13,6 +13,18 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+// Limits that keep a wish updatable. They live here rather than in the web
+// package because the page has to honour the same numbers the server enforces:
+// a form that offers what the server refuses is a bug in both directions.
+const (
+	// MaxReservations is how many live reservations one wish may carry.
+	MaxReservations = 100
+
+	// MaxQuantityPerRequest is how many items one reservation may claim on a
+	// wish with unlimited quantity, where nothing else bounds the request.
+	MaxQuantityPerRequest = 100
+)
+
 // Reservation represents a single reservation of one or more items.
 type Reservation struct {
 	// Quantity is the number of items reserved in this reservation.
@@ -74,7 +86,13 @@ type WishSpec struct {
 
 	// Quantity is the total number of items available for this wish.
 	// Defaults to 1 if not specified (backwards compatible).
-	// Set to 0 for unlimited quantity (users can reserve as many as they want).
+	// Set to 0 for unlimited quantity, meaning no stock to run out.
+	//
+	// Every wish, whatever its quantity, holds at most 100 live reservations
+	// at a time and refuses further ones until some expire. A single
+	// reservation is bounded by whatever stock is left, so a wish with 500
+	// items can be reserved 500 at once; on an unlimited wish, where nothing
+	// is left to run out, one reservation claims at most 100 items.
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:default=1
 	// +optional
@@ -192,6 +210,32 @@ func (w *Wish) ActiveReservations() []Reservation {
 	}
 
 	return active
+}
+
+// AtReservationLimit reports whether the wish already carries as many live
+// reservations as it can hold. Reserving is anonymous, so without a ceiling a
+// request loop grows status.reservations until the object no longer fits what
+// the API server accepts, after which nothing can update the wish again --
+// including the controller pass that would have pruned the list.
+func (w *Wish) AtReservationLimit() bool {
+	return len(w.ActiveReservations()) >= MaxReservations
+}
+
+// MaxReservableQuantity returns the largest quantity one reservation may claim
+// right now. Zero means the wish cannot take a reservation at all, so the same
+// call decides whether a reserve form is offered and how far it may go.
+func (w *Wish) MaxReservableQuantity() int32 {
+	if w.AtReservationLimit() {
+		return 0
+	}
+
+	// An unlimited wish has no stock to run out, so the per-request limit is
+	// the only thing bounding it. A limited one is bounded by what is left.
+	if w.IsUnlimited() {
+		return MaxQuantityPerRequest
+	}
+
+	return w.AvailableQuantity()
 }
 
 // IsFullyReserved returns true if all items are reserved.

--- a/api/v1alpha1/wish_types_test.go
+++ b/api/v1alpha1/wish_types_test.go
@@ -726,3 +726,78 @@ func TestWish_IsFullyReserved_Unlimited(t *testing.T) {
 		})
 	}
 }
+
+func TestWish_MaxReservableQuantity(t *testing.T) {
+	t.Parallel()
+
+	future := metav1.NewTime(time.Now().Add(time.Hour))
+	past := metav1.NewTime(time.Now().Add(-time.Hour))
+
+	full := make([]Reservation, MaxReservations)
+	for i := range full {
+		full[i] = Reservation{Quantity: 1, ExpiresAt: future}
+	}
+
+	expiredFull := make([]Reservation, MaxReservations)
+	for i := range expiredFull {
+		expiredFull[i] = Reservation{Quantity: 1, ExpiresAt: past}
+	}
+
+	tests := []struct {
+		name         string
+		quantity     int32
+		reservations []Reservation
+		atLimit      bool
+		expected     int32
+	}{
+		{
+			name:     "unlimited stops at the per-request limit",
+			quantity: 0,
+			expected: MaxQuantityPerRequest,
+		},
+		{
+			name:     "limited reports what is left, above the per-request limit",
+			quantity: 500,
+			expected: 500,
+		},
+		{
+			name:         "limited reports what is left",
+			quantity:     5,
+			reservations: []Reservation{{Quantity: 2, ExpiresAt: future}},
+			expected:     3,
+		},
+		{
+			name:         "at the reservation limit nothing can be reserved",
+			quantity:     1000,
+			reservations: full,
+			atLimit:      true,
+			expected:     0,
+		},
+		{
+			name:         "one below the reservation limit still takes one more",
+			quantity:     1000,
+			reservations: full[:MaxReservations-1],
+			expected:     1000 - (MaxReservations - 1),
+		},
+		{
+			name:         "expired entries do not fill the reservation limit",
+			quantity:     1000,
+			reservations: expiredFull,
+			expected:     1000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			wish := &Wish{
+				Spec:   WishSpec{Quantity: tt.quantity},
+				Status: WishStatus{Reservations: tt.reservations},
+			}
+
+			assert.Equal(t, tt.atLimit, wish.AtReservationLimit())
+			assert.Equal(t, tt.expected, wish.MaxReservableQuantity())
+		})
+	}
+}

--- a/charts/wish-operator/crds/wishlist.k8s.lex.la_wishes.yaml
+++ b/charts/wish-operator/crds/wishlist.k8s.lex.la_wishes.yaml
@@ -75,7 +75,13 @@ spec:
                 description: |-
                   Quantity is the total number of items available for this wish.
                   Defaults to 1 if not specified (backwards compatible).
-                  Set to 0 for unlimited quantity (users can reserve as many as they want).
+                  Set to 0 for unlimited quantity, meaning no stock to run out.
+
+                  Every wish, whatever its quantity, holds at most 100 live reservations
+                  at a time and refuses further ones until some expire. A single
+                  reservation is bounded by whatever stock is left, so a wish with 500
+                  items can be reserved 500 at once; on an unlimited wish, where nothing
+                  is left to run out, one reservation claims at most 100 items.
                 format: int32
                 minimum: 0
                 type: integer

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -93,8 +93,8 @@ var (
 // arguments positionally and two of them are ints, so a transposition compiles
 // and runs; this is the single place that mapping is written down, and the
 // place a test can pin it.
-func newWebServer(c client.Client, opts *webOptions) *web.Server {
-	return web.NewServer(c, opts.namespace, opts.trustedProxyHops, opts.rateLimit, opts.rateBurst)
+func newWebServer(c client.Client, reader client.Reader, opts *webOptions) *web.Server {
+	return web.NewServer(c, reader, opts.namespace, opts.trustedProxyHops, opts.rateLimit, opts.rateBurst)
 }
 
 // validateWebFlags rejects settings the flag package cannot express. Each one
@@ -288,7 +288,8 @@ func main() {
 	}
 
 	// Start web server
-	webServer := newWebServer(mgr.GetClient(), &webOpts)
+	// GetAPIReader bypasses the cache so a reservation retry sees the write it conflicted with.
+	webServer := newWebServer(mgr.GetClient(), mgr.GetAPIReader(), &webOpts)
 	if err := mgr.Add(&webRunnable{addr: webAddr, handler: webServer.Handler()}); err != nil {
 		setupLog.Error(err, "unable to add web server")
 		os.Exit(1)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -357,7 +357,7 @@ func TestNewWebServer_MapsFlagsOntoTheServer(t *testing.T) {
 			WithObjects(wishes...).
 			Build()
 
-		return newWebServer(fakeClient, opts).Handler()
+		return newWebServer(fakeClient, fakeClient, opts).Handler()
 	}
 
 	t.Run("hop count and burst are not transposed", func(t *testing.T) {

--- a/config/crd/bases/wishlist.k8s.lex.la_wishes.yaml
+++ b/config/crd/bases/wishlist.k8s.lex.la_wishes.yaml
@@ -75,7 +75,13 @@ spec:
                 description: |-
                   Quantity is the total number of items available for this wish.
                   Defaults to 1 if not specified (backwards compatible).
-                  Set to 0 for unlimited quantity (users can reserve as many as they want).
+                  Set to 0 for unlimited quantity, meaning no stock to run out.
+
+                  Every wish, whatever its quantity, holds at most 100 live reservations
+                  at a time and refuses further ones until some expire. A single
+                  reservation is bounded by whatever stock is left, so a wish with 500
+                  items can be reserved 500 at once; on an unlimited wish, where nothing
+                  is left to run out, one reservation claims at most 100 items.
                 format: int32
                 minimum: 0
                 type: integer

--- a/internal/i18n/messages.go
+++ b/internal/i18n/messages.go
@@ -21,18 +21,22 @@ const (
 	keyUnlimitedAvailable = "unlimited_available"
 	keyReservedCount      = "reserved_count"
 
-	keyErrListWishes      = "err_list_wishes"
-	keyErrRender          = "err_render"
-	keyErrMissingName     = "err_missing_name"
-	keyErrInvalidForm     = "err_invalid_form"
-	keyErrWeeksRange      = "err_weeks_range"
-	keyErrNotFound        = "err_not_found"
-	keyErrGetWish         = "err_get_wish"
-	keyErrReserveFailed   = "err_reserve_failed"
-	keyErrRateLimit       = "err_rate_limit"
-	keyErrInvalidQuantity = "err_invalid_quantity"
-	keyErrFullyReserved   = "err_fully_reserved"
-	keyErrQuantityExceeds = "err_quantity_exceeds"
+	keyErrListWishes         = "err_list_wishes"
+	keyErrRender             = "err_render"
+	keyErrMissingName        = "err_missing_name"
+	keyErrInvalidForm        = "err_invalid_form"
+	keyErrWeeksRange         = "err_weeks_range"
+	keyErrNotFound           = "err_not_found"
+	keyErrGetWish            = "err_get_wish"
+	keyErrReserveFailed      = "err_reserve_failed"
+	keyErrRateLimit          = "err_rate_limit"
+	keyErrInvalidQuantity    = "err_invalid_quantity"
+	keyErrFullyReserved      = "err_fully_reserved"
+	keyErrQuantityExceeds    = "err_quantity_exceeds"
+	keyErrReservationLimit   = "err_reservation_limit"
+	keyErrQuantityPerRequest = "err_quantity_per_request"
+	keyErrReserveBusy        = "err_reserve_busy"
+	keyErrNoResponse         = "err_no_response"
 )
 
 // ruWeeksMany is the Russian plural form for "weeks", shared by the
@@ -59,18 +63,22 @@ var messages = map[string]map[string]string{
 		keyReservedCount:      "%d reserved until %s",
 
 		// Error messages
-		keyErrListWishes:      "Failed to list wishes",
-		keyErrRender:          "Failed to render template",
-		keyErrMissingName:     "Missing wish name",
-		keyErrInvalidForm:     "Invalid form data",
-		keyErrWeeksRange:      "Weeks must be between %d and %d",
-		keyErrNotFound:        "Wish not found",
-		keyErrGetWish:         "Failed to get wish",
-		keyErrReserveFailed:   "Failed to reserve wish",
-		keyErrRateLimit:       "Too many requests",
-		keyErrInvalidQuantity: "Invalid quantity",
-		keyErrFullyReserved:   "All items are reserved",
-		keyErrQuantityExceeds: "Only %d available",
+		keyErrListWishes:         "Failed to list wishes",
+		keyErrRender:             "Failed to render template",
+		keyErrMissingName:        "Missing wish name",
+		keyErrInvalidForm:        "Invalid form data",
+		keyErrWeeksRange:         "Weeks must be between %d and %d",
+		keyErrNotFound:           "Wish not found",
+		keyErrGetWish:            "Failed to get wish",
+		keyErrReserveFailed:      "Failed to reserve wish",
+		keyErrRateLimit:          "Too many requests",
+		keyErrInvalidQuantity:    "Invalid quantity",
+		keyErrFullyReserved:      "All items are reserved",
+		keyErrQuantityExceeds:    "Only %d available",
+		keyErrReservationLimit:   "This wish cannot take any more reservations right now",
+		keyErrQuantityPerRequest: "At most %d per reservation",
+		keyErrReserveBusy:        "Someone else was reserving this at the same time. Try again.",
+		keyErrNoResponse:         "The request did not reach the server. Check your connection and try again.",
 	},
 	LangRU: {
 		// UI strings
@@ -90,18 +98,22 @@ var messages = map[string]map[string]string{
 		keyReservedCount:      "%d зарезервировано до %s",
 
 		// Error messages
-		keyErrListWishes:      "Не удалось загрузить список желаний",
-		keyErrRender:          "Ошибка отображения",
-		keyErrMissingName:     "Не указано название",
-		keyErrInvalidForm:     "Неверные данные формы",
-		keyErrWeeksRange:      "Срок должен быть от %d до %d недель",
-		keyErrNotFound:        "Желание не найдено",
-		keyErrGetWish:         "Не удалось получить желание",
-		keyErrReserveFailed:   "Не удалось зарезервировать",
-		keyErrRateLimit:       "Слишком много запросов",
-		keyErrInvalidQuantity: "Неверное количество",
-		keyErrFullyReserved:   "Всё зарезервировано",
-		keyErrQuantityExceeds: "Доступно только %d",
+		keyErrListWishes:         "Не удалось загрузить список желаний",
+		keyErrRender:             "Ошибка отображения",
+		keyErrMissingName:        "Не указано название",
+		keyErrInvalidForm:        "Неверные данные формы",
+		keyErrWeeksRange:         "Срок должен быть от %d до %d недель",
+		keyErrNotFound:           "Желание не найдено",
+		keyErrGetWish:            "Не удалось получить желание",
+		keyErrReserveFailed:      "Не удалось зарезервировать",
+		keyErrRateLimit:          "Слишком много запросов",
+		keyErrInvalidQuantity:    "Неверное количество",
+		keyErrFullyReserved:      "Всё зарезервировано",
+		keyErrQuantityExceeds:    "Доступно только %d",
+		keyErrReservationLimit:   "Это желание пока не может принять больше броней",
+		keyErrQuantityPerRequest: "Не больше %d за одну бронь",
+		keyErrReserveBusy:        "Кто-то бронировал это одновременно с вами. Попробуйте ещё раз.",
+		keyErrNoResponse:         "Запрос не дошёл до сервера. Проверьте соединение и попробуйте ещё раз.",
 	},
 	LangZH: {
 		// UI strings
@@ -119,17 +131,21 @@ var messages = map[string]map[string]string{
 		keyReservedCount:      "%d 已预订至 %s",
 
 		// Error messages
-		keyErrListWishes:      "无法加载愿望列表",
-		keyErrRender:          "渲染失败",
-		keyErrMissingName:     "缺少名称",
-		keyErrInvalidForm:     "表单数据无效",
-		keyErrWeeksRange:      "周数必须在%d到%d之间",
-		keyErrNotFound:        "未找到愿望",
-		keyErrGetWish:         "获取愿望失败",
-		keyErrReserveFailed:   "预订失败",
-		keyErrRateLimit:       "请求过多",
-		keyErrInvalidQuantity: "数量无效",
-		keyErrFullyReserved:   "全部已预订",
-		keyErrQuantityExceeds: "仅有 %d 件可用",
+		keyErrListWishes:         "无法加载愿望列表",
+		keyErrRender:             "渲染失败",
+		keyErrMissingName:        "缺少名称",
+		keyErrInvalidForm:        "表单数据无效",
+		keyErrWeeksRange:         "周数必须在%d到%d之间",
+		keyErrNotFound:           "未找到愿望",
+		keyErrGetWish:            "获取愿望失败",
+		keyErrReserveFailed:      "预订失败",
+		keyErrRateLimit:          "请求过多",
+		keyErrInvalidQuantity:    "数量无效",
+		keyErrFullyReserved:      "全部已预订",
+		keyErrQuantityExceeds:    "仅有 %d 件可用",
+		keyErrReservationLimit:   "该愿望暂时无法接受更多预订",
+		keyErrQuantityPerRequest: "每次预订最多 %d 件",
+		keyErrReserveBusy:        "有人同时在预订这件愿望，请再试一次。",
+		keyErrNoResponse:         "请求未送达服务器，请检查网络后重试。",
 	},
 }

--- a/internal/i18n/messages_internal_test.go
+++ b/internal/i18n/messages_internal_test.go
@@ -316,3 +316,57 @@ func translationKeyOf(call *ast.CallExpr) (string, bool) {
 
 	return key, true
 }
+
+// languageSpecificKeys are plural forms that exist only where the grammar
+// needs them. Weeks asks for these by language rather than by the caller's
+// locale, so they have no English counterpart and never will.
+func languageSpecificKeys() map[string]bool {
+	return map[string]bool{
+		keyWeeksFew:  true,
+		keyWeeksMany: true,
+	}
+}
+
+// TestMessagesCoverEveryLanguage pins two things TestCatalogsCoverEnglish does
+// not: that a format key keeps the same number of %d and %s verbs across
+// languages, since a translation that drops one renders %!s(MISSING) at
+// runtime; and that no catalog carries a key English lacks, which is usually a
+// typo, because every lookup starts from an English key. The one legitimate
+// exception is grammar English does not have, listed in languageSpecificKeys.
+func TestMessagesCoverEveryLanguage(t *testing.T) {
+	t.Parallel()
+
+	verbs := []string{"%d", "%s"}
+	pluralOnly := languageSpecificKeys()
+
+	for _, lang := range supportedLangs {
+		if lang == LangEN {
+			continue
+		}
+
+		for key, english := range messages[LangEN] {
+			translated, ok := messages[lang][key]
+			if !ok {
+				t.Errorf("catalog %q is missing key %q", lang, key)
+
+				continue
+			}
+
+			for _, verb := range verbs {
+				if strings.Count(english, verb) != strings.Count(translated, verb) {
+					t.Errorf("%s translation of %q has a different number of %s verbs", lang, key, verb)
+				}
+			}
+		}
+
+		for key := range messages[lang] {
+			if pluralOnly[key] {
+				continue
+			}
+
+			if _, ok := messages[LangEN][key]; !ok {
+				t.Errorf("%s has key %q that English does not", lang, key)
+			}
+		}
+	}
+}

--- a/internal/templates/index.templ
+++ b/internal/templates/index.templ
@@ -4,9 +4,26 @@
 package templates
 
 import (
+	"net/url"
+
 	wishlistv1alpha1 "github.com/lexfrei/wish-operator/api/v1alpha1"
 	"github.com/lexfrei/wish-operator/internal/i18n"
 )
+
+// refreshURL is the /wishes list the error banner reloads after a 409. It
+// carries the active tag so refreshing a filtered list does not silently reset
+// it to "All", and it is built with url.Values so a tag with a space or an
+// ampersand produces a valid query rather than a broken one.
+func refreshURL(lang, activeTag string) string {
+	q := url.Values{}
+	q.Set("lang", lang)
+
+	if activeTag != "" {
+		q.Set("tag", activeTag)
+	}
+
+	return "/wishes?" + q.Encode()
+}
 
 templ FilterBar(allTags []string, activeTag string, lang string) {
 	if len(allTags) > 0 {
@@ -112,7 +129,8 @@ templ Index(wishes []wishlistv1alpha1.Wish, allTags []string, activeTag string, 
 				.wish-card .purchase-links { margin-bottom: 1rem; font-size: 0.875rem; color: var(--text-secondary); }
 				.wish-card .purchase-links a { color: var(--accent-color); margin-left: 0.25rem; }
 				.wish-card .reserve-form { display: flex; gap: 0.5rem; }
-				.wish-card select, .wish-card button { padding: 0.5rem 1rem; border-radius: 6px; border: 1px solid var(--border-color); background: var(--bg-card); color: var(--text-primary); }
+				.wish-card select, .wish-card input, .wish-card button { padding: 0.5rem 1rem; border-radius: 6px; border: 1px solid var(--border-color); background: var(--bg-card); color: var(--text-primary); }
+				.wish-card input[type="number"] { width: 5.5rem; }
 				.wish-card button { background: var(--accent-color); color: white; border: none; cursor: pointer; }
 				.wish-card button:hover { background: var(--accent-hover); }
 				.wish-card.fully-reserved { opacity: 0.7; }
@@ -127,6 +145,8 @@ templ Index(wishes []wishlistv1alpha1.Wish, allTags []string, activeTag string, 
 				.filter-chip { padding: 0.375rem 0.875rem; border-radius: 9999px; font-size: 0.875rem; cursor: pointer; border: 1px solid var(--border-color); background: var(--chip-bg); color: var(--text-muted); transition: all 0.15s; text-decoration: none; }
 				.filter-chip:hover { background: var(--chip-hover); border-color: var(--border-hover); }
 				.filter-chip.active { background: var(--accent-color); color: white; border-color: var(--accent-color); }
+				#error-banner { margin-bottom: 1rem; padding: 0.75rem 1rem; border-radius: 6px; background: #b3261e; color: #fff; }
+				#error-banner[hidden] { display: none; }
 				.footer { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--footer-border); text-align: center; }
 				.footer-row { display: flex; justify-content: center; gap: 1rem; margin-bottom: 0.75rem; }
 				.footer-row:last-child { margin-bottom: 0; }
@@ -138,6 +158,17 @@ templ Index(wishes []wishlistv1alpha1.Wish, allTags []string, activeTag string, 
 		<body>
 			<div class="container">
 				<h1>{ i18n.T(lang, "page_title") }</h1>
+				// htmx drops the body of a non-2xx response, so every refusal the
+				// server explains lands here instead of being swapped into a card.
+				// The script cannot reach i18n, so the strings it needs when the
+				// response carries none of its own are rendered here.
+				<div
+					id="error-banner"
+					role="alert"
+					data-fallback={ i18n.T(lang, "err_no_response") }
+					data-refresh={ refreshURL(lang, activeTag) }
+					hidden
+				></div>
 				<div id="wish-content">
 					@WishContent(wishes, allTags, activeTag, lang)
 				</div>
@@ -155,6 +186,76 @@ templ Index(wishes []wishlistv1alpha1.Wish, allTags []string, activeTag string, 
 				</footer>
 			</div>
 			<script>
+				(function() {
+					let hideTimer;
+					function banner() {
+						return document.getElementById('error-banner');
+					}
+					function show(text) {
+						const el = banner();
+						if (!el) {
+							return;
+						}
+						// A dropped or timed-out request carries no body, and those are
+						// exactly the cases where saying nothing looks like a dead button.
+						const message = (text || '').trim() || el.dataset.fallback || '';
+						if (!message) {
+							return;
+						}
+						// Unhide before writing: a live region mutated inside a hidden
+						// subtree is not announced.
+						el.hidden = false;
+						el.textContent = message;
+						// The form may sit far down the grid, and an unread message
+						// above the fold is a silent failure of its own.
+						el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+						clearTimeout(hideTimer);
+						hideTimer = setTimeout(function() { el.hidden = true; }, 6000);
+					}
+					document.addEventListener('htmx:afterRequest', function(evt) {
+						// A refusal followed by a success would otherwise leave the
+						// old message hanging over the card that just worked.
+						if (!evt.detail.successful) {
+							return;
+						}
+						const el = banner();
+						if (!el) {
+							return;
+						}
+						// The 409 handler below issues its own refresh, which also
+						// succeeds. Keyed on the path rather than a flag so the failed
+						// POST's own afterRequest cannot consume the signal first: that
+						// refresh must not clear the message that triggered it.
+						const cfg = evt.detail.requestConfig;
+						if (cfg && cfg.path === el.dataset.refresh) {
+							return;
+						}
+						el.hidden = true;
+						clearTimeout(hideTimer);
+					});
+					document.addEventListener('htmx:responseError', function(evt) {
+						// The server's own refusals are text/plain. A gateway between
+						// it and the visitor answers a 502 with an HTML error page, and
+						// that must not land in the banner as markup shown as text, so
+						// anything else falls back to the generic message.
+						const xhr = evt.detail.xhr;
+						const contentType = xhr.getResponseHeader('Content-Type') || '';
+						show(contentType.indexOf('text/plain') === 0 ? xhr.responseText : '');
+						// A 409 means the wish moved on without this page: the card is
+						// still offering a form that cannot succeed, so replace it with
+						// what the server now has.
+						const el = banner();
+						if (evt.detail.xhr.status === 409 && el && el.dataset.refresh) {
+							htmx.ajax('GET', el.dataset.refresh, '#wish-content');
+						}
+					});
+					document.addEventListener('htmx:sendError', function() {
+						show('');
+					});
+					document.addEventListener('htmx:timeout', function() {
+						show('');
+					});
+				})();
 				function setTheme(theme) {
 					localStorage.setItem('theme', theme);
 					updateTheme();

--- a/internal/templates/index_templ.go
+++ b/internal/templates/index_templ.go
@@ -13,9 +13,26 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
+	"net/url"
+
 	wishlistv1alpha1 "github.com/lexfrei/wish-operator/api/v1alpha1"
 	"github.com/lexfrei/wish-operator/internal/i18n"
 )
+
+// refreshURL is the /wishes list the error banner reloads after a 409. It
+// carries the active tag so refreshing a filtered list does not silently reset
+// it to "All", and it is built with url.Values so a tag with a space or an
+// ampersand produces a valid query rather than a broken one.
+func refreshURL(lang, activeTag string) string {
+	q := url.Values{}
+	q.Set("lang", lang)
+
+	if activeTag != "" {
+		q.Set("tag", activeTag)
+	}
+
+	return "/wishes?" + q.Encode()
+}
 
 func FilterBar(allTags []string, activeTag string, lang string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
@@ -46,7 +63,7 @@ func FilterBar(allTags []string, activeTag string, lang string) templ.Component 
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(lang, "filter_label"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 14, Col: 60}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 31, Col: 60}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
@@ -81,7 +98,7 @@ func FilterBar(allTags []string, activeTag string, lang string) templ.Component 
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.ResolveAttributeValue("/wishes?lang=" + lang)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 18, Col: 35}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 35, Col: 35}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var5)
 			if templ_7745c5c3_Err != nil {
@@ -94,7 +111,7 @@ func FilterBar(allTags []string, activeTag string, lang string) templ.Component 
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(lang, "filter_all"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 22, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 39, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -117,7 +134,7 @@ func FilterBar(allTags []string, activeTag string, lang string) templ.Component 
 				var templ_7745c5c3_Var8 templ.SafeURL
 				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/?tag=" + tag))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 25, Col: 41}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 42, Col: 41}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 				if templ_7745c5c3_Err != nil {
@@ -143,7 +160,7 @@ func FilterBar(allTags []string, activeTag string, lang string) templ.Component 
 				var templ_7745c5c3_Var10 string
 				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.ResolveAttributeValue("/wishes?tag=" + tag + "&lang=" + lang)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 27, Col: 52}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 44, Col: 52}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var10)
 				if templ_7745c5c3_Err != nil {
@@ -156,7 +173,7 @@ func FilterBar(allTags []string, activeTag string, lang string) templ.Component 
 				var templ_7745c5c3_Var11 string
 				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.ResolveAttributeValue("/?tag=" + tag)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 30, Col: 33}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 47, Col: 33}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var11)
 				if templ_7745c5c3_Err != nil {
@@ -169,7 +186,7 @@ func FilterBar(allTags []string, activeTag string, lang string) templ.Component 
 				var templ_7745c5c3_Var12 string
 				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(tag)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 31, Col: 10}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 48, Col: 10}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
@@ -217,7 +234,7 @@ func Index(wishes []wishlistv1alpha1.Wish, allTags []string, activeTag string, l
 		var templ_7745c5c3_Var14 string
 		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.ResolveAttributeValue(lang)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 39, Col: 18}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 56, Col: 18}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var14)
 		if templ_7745c5c3_Err != nil {
@@ -230,26 +247,52 @@ func Index(wishes []wishlistv1alpha1.Wish, allTags []string, activeTag string, l
 		var templ_7745c5c3_Var15 string
 		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(lang, "page_title"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 43, Col: 38}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 60, Col: 38}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</title><script src=\"https://unpkg.com/htmx.org@2.0.4\"></script><script>\n\t\t\t\t(function() {\n\t\t\t\t\tconst theme = localStorage.getItem('theme');\n\t\t\t\t\tif (theme === 'dark' || (theme === 'auto' || !theme) && window.matchMedia('(prefers-color-scheme: dark)').matches) {\n\t\t\t\t\t\tdocument.documentElement.setAttribute('data-theme', 'dark');\n\t\t\t\t\t}\n\t\t\t\t})();\n\t\t\t</script><style>\n\t\t\t\t:root {\n\t\t\t\t\t--bg-primary: #f5f5f5;\n\t\t\t\t\t--bg-card: #ffffff;\n\t\t\t\t\t--text-primary: #333333;\n\t\t\t\t\t--text-secondary: #6b7280;\n\t\t\t\t\t--text-muted: #374151;\n\t\t\t\t\t--border-color: #d1d5db;\n\t\t\t\t\t--border-hover: #9ca3af;\n\t\t\t\t\t--accent-color: #2563eb;\n\t\t\t\t\t--accent-hover: #1d4ed8;\n\t\t\t\t\t--tag-bg: #e5e7eb;\n\t\t\t\t\t--tag-context-bg: #dbeafe;\n\t\t\t\t\t--tag-context-text: #1d4ed8;\n\t\t\t\t\t--reserved-bg: #fef3c7;\n\t\t\t\t\t--reserved-text: #92400e;\n\t\t\t\t\t--stars-color: #fbbf24;\n\t\t\t\t\t--chip-bg: #ffffff;\n\t\t\t\t\t--chip-hover: #f3f4f6;\n\t\t\t\t\t--shadow: rgba(0,0,0,0.1);\n\t\t\t\t\t--footer-border: #e5e7eb;\n\t\t\t\t}\n\t\t\t\t[data-theme=\"dark\"] {\n\t\t\t\t\t--bg-primary: #1a1a2e;\n\t\t\t\t\t--bg-card: #16213e;\n\t\t\t\t\t--text-primary: #e4e4e7;\n\t\t\t\t\t--text-secondary: #a1a1aa;\n\t\t\t\t\t--text-muted: #d4d4d8;\n\t\t\t\t\t--border-color: #3f3f46;\n\t\t\t\t\t--border-hover: #52525b;\n\t\t\t\t\t--accent-color: #3b82f6;\n\t\t\t\t\t--accent-hover: #2563eb;\n\t\t\t\t\t--tag-bg: #27272a;\n\t\t\t\t\t--tag-context-bg: #1e3a5f;\n\t\t\t\t\t--tag-context-text: #60a5fa;\n\t\t\t\t\t--reserved-bg: #422006;\n\t\t\t\t\t--reserved-text: #fbbf24;\n\t\t\t\t\t--stars-color: #fbbf24;\n\t\t\t\t\t--chip-bg: #27272a;\n\t\t\t\t\t--chip-hover: #3f3f46;\n\t\t\t\t\t--shadow: rgba(0,0,0,0.3);\n\t\t\t\t\t--footer-border: #3f3f46;\n\t\t\t\t}\n\t\t\t\t* { box-sizing: border-box; margin: 0; padding: 0; }\n\t\t\t\tbody { font-family: system-ui, -apple-system, sans-serif; background: var(--bg-primary); padding: 2rem; color: var(--text-primary); transition: background 0.3s, color 0.3s; }\n\t\t\t\t.container { max-width: 1200px; margin: 0 auto; }\n\t\t\t\th1 { text-align: center; margin-bottom: 2rem; color: var(--text-primary); }\n\t\t\t\t.wishes { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.5rem; }\n\t\t\t\t.wish-card { background: var(--bg-card); border-radius: 12px; padding: 1.5rem; box-shadow: 0 2px 8px var(--shadow); transition: background 0.3s; }\n\t\t\t\t.wish-card img { width: 100%; height: 200px; object-fit: contain; border-radius: 8px; margin-bottom: 1rem; }\n\t\t\t\t.wish-card h2 { font-size: 1.25rem; margin-bottom: 0.5rem; color: var(--text-primary); }\n\t\t\t\t.wish-card h2 a { color: var(--accent-color); text-decoration: none; }\n\t\t\t\t.wish-card h2 a:hover { text-decoration: underline; }\n\t\t\t\t.wish-card .price { font-size: 1.5rem; font-weight: bold; color: var(--accent-color); margin-bottom: 0.5rem; }\n\t\t\t\t.wish-card .stars { color: var(--stars-color); margin-bottom: 0.5rem; }\n\t\t\t\t.wish-card .tags { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1rem; }\n\t\t\t\t.wish-card .tag { background: var(--tag-bg); color: var(--text-secondary); padding: 0.25rem 0.75rem; border-radius: 9999px; font-size: 0.875rem; }\n\t\t\t\t.wish-card .context-tag { background: var(--tag-context-bg); color: var(--tag-context-text); }\n\t\t\t\t.wish-card .description { color: var(--text-secondary); font-size: 0.875rem; margin-bottom: 1rem; }\n\t\t\t\t.wish-card .purchase-links { margin-bottom: 1rem; font-size: 0.875rem; color: var(--text-secondary); }\n\t\t\t\t.wish-card .purchase-links a { color: var(--accent-color); margin-left: 0.25rem; }\n\t\t\t\t.wish-card .reserve-form { display: flex; gap: 0.5rem; }\n\t\t\t\t.wish-card select, .wish-card button { padding: 0.5rem 1rem; border-radius: 6px; border: 1px solid var(--border-color); background: var(--bg-card); color: var(--text-primary); }\n\t\t\t\t.wish-card button { background: var(--accent-color); color: white; border: none; cursor: pointer; }\n\t\t\t\t.wish-card button:hover { background: var(--accent-hover); }\n\t\t\t\t.wish-card.fully-reserved { opacity: 0.7; }\n\t\t\t\t.wish-card .quantity-info { font-size: 0.875rem; color: var(--text-secondary); margin-bottom: 0.5rem; }\n\t\t\t\t.wish-card .quantity-info.unlimited { color: #10b981; font-weight: 600; }\n\t\t\t\t.wish-card .reservations-list { margin-bottom: 1rem; }\n\t\t\t\t.wish-card .reservation-item { font-size: 0.75rem; color: var(--reserved-text); background: var(--reserved-bg); padding: 0.25rem 0.5rem; border-radius: 4px; margin-bottom: 0.25rem; }\n\t\t\t\t.wish-card .fully-reserved-badge { background: var(--reserved-bg); color: var(--reserved-text); padding: 0.5rem 1rem; border-radius: 6px; text-align: center; }\n\t\t\t\t.empty { text-align: center; color: var(--text-secondary); padding: 4rem; }\n\t\t\t\t.filter-bar { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1.5rem; align-items: center; }\n\t\t\t\t.filter-label { font-weight: 500; color: var(--text-muted); margin-right: 0.5rem; }\n\t\t\t\t.filter-chip { padding: 0.375rem 0.875rem; border-radius: 9999px; font-size: 0.875rem; cursor: pointer; border: 1px solid var(--border-color); background: var(--chip-bg); color: var(--text-muted); transition: all 0.15s; text-decoration: none; }\n\t\t\t\t.filter-chip:hover { background: var(--chip-hover); border-color: var(--border-hover); }\n\t\t\t\t.filter-chip.active { background: var(--accent-color); color: white; border-color: var(--accent-color); }\n\t\t\t\t.footer { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--footer-border); text-align: center; }\n\t\t\t\t.footer-row { display: flex; justify-content: center; gap: 1rem; margin-bottom: 0.75rem; }\n\t\t\t\t.footer-row:last-child { margin-bottom: 0; }\n\t\t\t\t.lang-selector a, .theme-selector button { font-size: 1.5rem; text-decoration: none; opacity: 0.6; transition: opacity 0.15s; background: none; border: none; cursor: pointer; padding: 0.25rem; }\n\t\t\t\t.lang-selector a:hover, .theme-selector button:hover { opacity: 1; }\n\t\t\t\t.lang-selector a.active, .theme-selector button.active { opacity: 1; }\n\t\t\t</style></head><body><div class=\"container\"><h1>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</title><script src=\"https://unpkg.com/htmx.org@2.0.4\"></script><script>\n\t\t\t\t(function() {\n\t\t\t\t\tconst theme = localStorage.getItem('theme');\n\t\t\t\t\tif (theme === 'dark' || (theme === 'auto' || !theme) && window.matchMedia('(prefers-color-scheme: dark)').matches) {\n\t\t\t\t\t\tdocument.documentElement.setAttribute('data-theme', 'dark');\n\t\t\t\t\t}\n\t\t\t\t})();\n\t\t\t</script><style>\n\t\t\t\t:root {\n\t\t\t\t\t--bg-primary: #f5f5f5;\n\t\t\t\t\t--bg-card: #ffffff;\n\t\t\t\t\t--text-primary: #333333;\n\t\t\t\t\t--text-secondary: #6b7280;\n\t\t\t\t\t--text-muted: #374151;\n\t\t\t\t\t--border-color: #d1d5db;\n\t\t\t\t\t--border-hover: #9ca3af;\n\t\t\t\t\t--accent-color: #2563eb;\n\t\t\t\t\t--accent-hover: #1d4ed8;\n\t\t\t\t\t--tag-bg: #e5e7eb;\n\t\t\t\t\t--tag-context-bg: #dbeafe;\n\t\t\t\t\t--tag-context-text: #1d4ed8;\n\t\t\t\t\t--reserved-bg: #fef3c7;\n\t\t\t\t\t--reserved-text: #92400e;\n\t\t\t\t\t--stars-color: #fbbf24;\n\t\t\t\t\t--chip-bg: #ffffff;\n\t\t\t\t\t--chip-hover: #f3f4f6;\n\t\t\t\t\t--shadow: rgba(0,0,0,0.1);\n\t\t\t\t\t--footer-border: #e5e7eb;\n\t\t\t\t}\n\t\t\t\t[data-theme=\"dark\"] {\n\t\t\t\t\t--bg-primary: #1a1a2e;\n\t\t\t\t\t--bg-card: #16213e;\n\t\t\t\t\t--text-primary: #e4e4e7;\n\t\t\t\t\t--text-secondary: #a1a1aa;\n\t\t\t\t\t--text-muted: #d4d4d8;\n\t\t\t\t\t--border-color: #3f3f46;\n\t\t\t\t\t--border-hover: #52525b;\n\t\t\t\t\t--accent-color: #3b82f6;\n\t\t\t\t\t--accent-hover: #2563eb;\n\t\t\t\t\t--tag-bg: #27272a;\n\t\t\t\t\t--tag-context-bg: #1e3a5f;\n\t\t\t\t\t--tag-context-text: #60a5fa;\n\t\t\t\t\t--reserved-bg: #422006;\n\t\t\t\t\t--reserved-text: #fbbf24;\n\t\t\t\t\t--stars-color: #fbbf24;\n\t\t\t\t\t--chip-bg: #27272a;\n\t\t\t\t\t--chip-hover: #3f3f46;\n\t\t\t\t\t--shadow: rgba(0,0,0,0.3);\n\t\t\t\t\t--footer-border: #3f3f46;\n\t\t\t\t}\n\t\t\t\t* { box-sizing: border-box; margin: 0; padding: 0; }\n\t\t\t\tbody { font-family: system-ui, -apple-system, sans-serif; background: var(--bg-primary); padding: 2rem; color: var(--text-primary); transition: background 0.3s, color 0.3s; }\n\t\t\t\t.container { max-width: 1200px; margin: 0 auto; }\n\t\t\t\th1 { text-align: center; margin-bottom: 2rem; color: var(--text-primary); }\n\t\t\t\t.wishes { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.5rem; }\n\t\t\t\t.wish-card { background: var(--bg-card); border-radius: 12px; padding: 1.5rem; box-shadow: 0 2px 8px var(--shadow); transition: background 0.3s; }\n\t\t\t\t.wish-card img { width: 100%; height: 200px; object-fit: contain; border-radius: 8px; margin-bottom: 1rem; }\n\t\t\t\t.wish-card h2 { font-size: 1.25rem; margin-bottom: 0.5rem; color: var(--text-primary); }\n\t\t\t\t.wish-card h2 a { color: var(--accent-color); text-decoration: none; }\n\t\t\t\t.wish-card h2 a:hover { text-decoration: underline; }\n\t\t\t\t.wish-card .price { font-size: 1.5rem; font-weight: bold; color: var(--accent-color); margin-bottom: 0.5rem; }\n\t\t\t\t.wish-card .stars { color: var(--stars-color); margin-bottom: 0.5rem; }\n\t\t\t\t.wish-card .tags { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1rem; }\n\t\t\t\t.wish-card .tag { background: var(--tag-bg); color: var(--text-secondary); padding: 0.25rem 0.75rem; border-radius: 9999px; font-size: 0.875rem; }\n\t\t\t\t.wish-card .context-tag { background: var(--tag-context-bg); color: var(--tag-context-text); }\n\t\t\t\t.wish-card .description { color: var(--text-secondary); font-size: 0.875rem; margin-bottom: 1rem; }\n\t\t\t\t.wish-card .purchase-links { margin-bottom: 1rem; font-size: 0.875rem; color: var(--text-secondary); }\n\t\t\t\t.wish-card .purchase-links a { color: var(--accent-color); margin-left: 0.25rem; }\n\t\t\t\t.wish-card .reserve-form { display: flex; gap: 0.5rem; }\n\t\t\t\t.wish-card select, .wish-card input, .wish-card button { padding: 0.5rem 1rem; border-radius: 6px; border: 1px solid var(--border-color); background: var(--bg-card); color: var(--text-primary); }\n\t\t\t\t.wish-card input[type=\"number\"] { width: 5.5rem; }\n\t\t\t\t.wish-card button { background: var(--accent-color); color: white; border: none; cursor: pointer; }\n\t\t\t\t.wish-card button:hover { background: var(--accent-hover); }\n\t\t\t\t.wish-card.fully-reserved { opacity: 0.7; }\n\t\t\t\t.wish-card .quantity-info { font-size: 0.875rem; color: var(--text-secondary); margin-bottom: 0.5rem; }\n\t\t\t\t.wish-card .quantity-info.unlimited { color: #10b981; font-weight: 600; }\n\t\t\t\t.wish-card .reservations-list { margin-bottom: 1rem; }\n\t\t\t\t.wish-card .reservation-item { font-size: 0.75rem; color: var(--reserved-text); background: var(--reserved-bg); padding: 0.25rem 0.5rem; border-radius: 4px; margin-bottom: 0.25rem; }\n\t\t\t\t.wish-card .fully-reserved-badge { background: var(--reserved-bg); color: var(--reserved-text); padding: 0.5rem 1rem; border-radius: 6px; text-align: center; }\n\t\t\t\t.empty { text-align: center; color: var(--text-secondary); padding: 4rem; }\n\t\t\t\t.filter-bar { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1.5rem; align-items: center; }\n\t\t\t\t.filter-label { font-weight: 500; color: var(--text-muted); margin-right: 0.5rem; }\n\t\t\t\t.filter-chip { padding: 0.375rem 0.875rem; border-radius: 9999px; font-size: 0.875rem; cursor: pointer; border: 1px solid var(--border-color); background: var(--chip-bg); color: var(--text-muted); transition: all 0.15s; text-decoration: none; }\n\t\t\t\t.filter-chip:hover { background: var(--chip-hover); border-color: var(--border-hover); }\n\t\t\t\t.filter-chip.active { background: var(--accent-color); color: white; border-color: var(--accent-color); }\n\t\t\t\t#error-banner { margin-bottom: 1rem; padding: 0.75rem 1rem; border-radius: 6px; background: #b3261e; color: #fff; }\n\t\t\t\t#error-banner[hidden] { display: none; }\n\t\t\t\t.footer { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--footer-border); text-align: center; }\n\t\t\t\t.footer-row { display: flex; justify-content: center; gap: 1rem; margin-bottom: 0.75rem; }\n\t\t\t\t.footer-row:last-child { margin-bottom: 0; }\n\t\t\t\t.lang-selector a, .theme-selector button { font-size: 1.5rem; text-decoration: none; opacity: 0.6; transition: opacity 0.15s; background: none; border: none; cursor: pointer; padding: 0.25rem; }\n\t\t\t\t.lang-selector a:hover, .theme-selector button:hover { opacity: 1; }\n\t\t\t\t.lang-selector a.active, .theme-selector button.active { opacity: 1; }\n\t\t\t</style></head><body><div class=\"container\"><h1>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var16 string
 		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(lang, "page_title"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 140, Col: 36}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 160, Col: 36}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</h1><div id=\"wish-content\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</h1><div id=\"error-banner\" role=\"alert\" data-fallback=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var17 string
+		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.ResolveAttributeValue(i18n.T(lang, "err_no_response"))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 168, Col: 52}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var17)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" data-refresh=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var18 string
+		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.ResolveAttributeValue(refreshURL(lang, activeTag))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 169, Col: 47}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var18)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\" hidden></div><div id=\"wish-content\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -257,38 +300,16 @@ func Index(wishes []wishlistv1alpha1.Wish, allTags []string, activeTag string, l
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div><footer class=\"footer\"><div class=\"footer-row lang-selector\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</div><footer class=\"footer\"><div class=\"footer-row lang-selector\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var17 = []any{templ.KV("active", lang == "en")}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var17...)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<a href=\"/?lang=en\" class=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var18 string
-		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var17).String())
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 1, Col: 0}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var18)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\" title=\"English\">🇬🇧</a> ")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var19 = []any{templ.KV("active", lang == "ru")}
+		var templ_7745c5c3_Var19 = []any{templ.KV("active", lang == "en")}
 		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var19...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<a href=\"/?lang=ru\" class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<a href=\"/?lang=en\" class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -301,16 +322,16 @@ func Index(wishes []wishlistv1alpha1.Wish, allTags []string, activeTag string, l
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\" title=\"Русский\">🇷🇺</a> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\" title=\"English\">🇬🇧</a> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var21 = []any{templ.KV("active", lang == "zh")}
+		var templ_7745c5c3_Var21 = []any{templ.KV("active", lang == "ru")}
 		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var21...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<a href=\"/?lang=zh\" class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<a href=\"/?lang=ru\" class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -323,7 +344,29 @@ func Index(wishes []wishlistv1alpha1.Wish, allTags []string, activeTag string, l
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\" title=\"中文\">🇨🇳</a></div><div class=\"footer-row theme-selector\"><button onclick=\"setTheme('light')\" id=\"theme-light\" title=\"Light\">☀️</button> <button onclick=\"setTheme('auto')\" id=\"theme-auto\" title=\"Auto\">🌓</button> <button onclick=\"setTheme('dark')\" id=\"theme-dark\" title=\"Dark\">🌙</button></div></footer></div><script>\n\t\t\t\tfunction setTheme(theme) {\n\t\t\t\t\tlocalStorage.setItem('theme', theme);\n\t\t\t\t\tupdateTheme();\n\t\t\t\t}\n\t\t\t\tfunction updateTheme() {\n\t\t\t\t\tconst theme = localStorage.getItem('theme') || 'auto';\n\t\t\t\t\tconst isDark = theme === 'dark' || (theme === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches);\n\t\t\t\t\tdocument.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');\n\t\t\t\t\tdocument.querySelectorAll('.theme-selector button').forEach(btn => btn.classList.remove('active'));\n\t\t\t\t\tdocument.getElementById('theme-' + theme)?.classList.add('active');\n\t\t\t\t}\n\t\t\t\tupdateTheme();\n\t\t\t\twindow.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', updateTheme);\n\t\t\t</script></body></html>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\" title=\"Русский\">🇷🇺</a> ")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var23 = []any{templ.KV("active", lang == "zh")}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var23...)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<a href=\"/?lang=zh\" class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var24 string
+		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var23).String())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/index.templ`, Line: 1, Col: 0}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var24)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\" title=\"中文\">🇨🇳</a></div><div class=\"footer-row theme-selector\"><button onclick=\"setTheme('light')\" id=\"theme-light\" title=\"Light\">☀️</button> <button onclick=\"setTheme('auto')\" id=\"theme-auto\" title=\"Auto\">🌓</button> <button onclick=\"setTheme('dark')\" id=\"theme-dark\" title=\"Dark\">🌙</button></div></footer></div><script>\n\t\t\t\t(function() {\n\t\t\t\t\tlet hideTimer;\n\t\t\t\t\tfunction banner() {\n\t\t\t\t\t\treturn document.getElementById('error-banner');\n\t\t\t\t\t}\n\t\t\t\t\tfunction show(text) {\n\t\t\t\t\t\tconst el = banner();\n\t\t\t\t\t\tif (!el) {\n\t\t\t\t\t\t\treturn;\n\t\t\t\t\t\t}\n\t\t\t\t\t\t// A dropped or timed-out request carries no body, and those are\n\t\t\t\t\t\t// exactly the cases where saying nothing looks like a dead button.\n\t\t\t\t\t\tconst message = (text || '').trim() || el.dataset.fallback || '';\n\t\t\t\t\t\tif (!message) {\n\t\t\t\t\t\t\treturn;\n\t\t\t\t\t\t}\n\t\t\t\t\t\t// Unhide before writing: a live region mutated inside a hidden\n\t\t\t\t\t\t// subtree is not announced.\n\t\t\t\t\t\tel.hidden = false;\n\t\t\t\t\t\tel.textContent = message;\n\t\t\t\t\t\t// The form may sit far down the grid, and an unread message\n\t\t\t\t\t\t// above the fold is a silent failure of its own.\n\t\t\t\t\t\tel.scrollIntoView({ block: 'nearest', behavior: 'smooth' });\n\t\t\t\t\t\tclearTimeout(hideTimer);\n\t\t\t\t\t\thideTimer = setTimeout(function() { el.hidden = true; }, 6000);\n\t\t\t\t\t}\n\t\t\t\t\tdocument.addEventListener('htmx:afterRequest', function(evt) {\n\t\t\t\t\t\t// A refusal followed by a success would otherwise leave the\n\t\t\t\t\t\t// old message hanging over the card that just worked.\n\t\t\t\t\t\tif (!evt.detail.successful) {\n\t\t\t\t\t\t\treturn;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tconst el = banner();\n\t\t\t\t\t\tif (!el) {\n\t\t\t\t\t\t\treturn;\n\t\t\t\t\t\t}\n\t\t\t\t\t\t// The 409 handler below issues its own refresh, which also\n\t\t\t\t\t\t// succeeds. Keyed on the path rather than a flag so the failed\n\t\t\t\t\t\t// POST's own afterRequest cannot consume the signal first: that\n\t\t\t\t\t\t// refresh must not clear the message that triggered it.\n\t\t\t\t\t\tconst cfg = evt.detail.requestConfig;\n\t\t\t\t\t\tif (cfg && cfg.path === el.dataset.refresh) {\n\t\t\t\t\t\t\treturn;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tel.hidden = true;\n\t\t\t\t\t\tclearTimeout(hideTimer);\n\t\t\t\t\t});\n\t\t\t\t\tdocument.addEventListener('htmx:responseError', function(evt) {\n\t\t\t\t\t\t// The server's own refusals are text/plain. A gateway between\n\t\t\t\t\t\t// it and the visitor answers a 502 with an HTML error page, and\n\t\t\t\t\t\t// that must not land in the banner as markup shown as text, so\n\t\t\t\t\t\t// anything else falls back to the generic message.\n\t\t\t\t\t\tconst xhr = evt.detail.xhr;\n\t\t\t\t\t\tconst contentType = xhr.getResponseHeader('Content-Type') || '';\n\t\t\t\t\t\tshow(contentType.indexOf('text/plain') === 0 ? xhr.responseText : '');\n\t\t\t\t\t\t// A 409 means the wish moved on without this page: the card is\n\t\t\t\t\t\t// still offering a form that cannot succeed, so replace it with\n\t\t\t\t\t\t// what the server now has.\n\t\t\t\t\t\tconst el = banner();\n\t\t\t\t\t\tif (evt.detail.xhr.status === 409 && el && el.dataset.refresh) {\n\t\t\t\t\t\t\thtmx.ajax('GET', el.dataset.refresh, '#wish-content');\n\t\t\t\t\t\t}\n\t\t\t\t\t});\n\t\t\t\t\tdocument.addEventListener('htmx:sendError', function() {\n\t\t\t\t\t\tshow('');\n\t\t\t\t\t});\n\t\t\t\t\tdocument.addEventListener('htmx:timeout', function() {\n\t\t\t\t\t\tshow('');\n\t\t\t\t\t});\n\t\t\t\t})();\n\t\t\t\tfunction setTheme(theme) {\n\t\t\t\t\tlocalStorage.setItem('theme', theme);\n\t\t\t\t\tupdateTheme();\n\t\t\t\t}\n\t\t\t\tfunction updateTheme() {\n\t\t\t\t\tconst theme = localStorage.getItem('theme') || 'auto';\n\t\t\t\t\tconst isDark = theme === 'dark' || (theme === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches);\n\t\t\t\t\tdocument.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');\n\t\t\t\t\tdocument.querySelectorAll('.theme-selector button').forEach(btn => btn.classList.remove('active'));\n\t\t\t\t\tdocument.getElementById('theme-' + theme)?.classList.add('active');\n\t\t\t\t}\n\t\t\t\tupdateTheme();\n\t\t\t\twindow.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', updateTheme);\n\t\t\t</script></body></html>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/templates/wish_card.templ
+++ b/internal/templates/wish_card.templ
@@ -30,7 +30,16 @@ func repeatRune(r rune, count int) string {
 }
 
 templ WishCard(wish *wishlistv1alpha1.Wish, lang string) {
-	<div id={ fmt.Sprintf("wish-%s", wish.Name) } class={ "wish-card", templ.KV("fully-reserved", wish.IsFullyReserved()) }>
+	// Both of these walk the reservation slice and ActiveReservations
+	// allocates, so ask once per card rather than once per mention.
+	{{ reservable := wish.MaxReservableQuantity() }}
+	{{ active := wish.ActiveReservations() }}
+	{{ atLimit := wish.AtReservationLimit() }}
+	<div
+		id={ fmt.Sprintf("wish-%s", wish.Name) }
+		class={ "wish-card",
+			templ.KV("fully-reserved", wish.IsFullyReserved() || atLimit) }
+	>
 		if wish.Spec.ImageURL != "" {
 			<img src={ wish.Spec.ImageURL } alt={ wish.Spec.Title }/>
 		}
@@ -77,34 +86,35 @@ templ WishCard(wish *wishlistv1alpha1.Wish, lang string) {
 			</div>
 		}
 		// Show reservation list
-		if len(wish.ActiveReservations()) > 0 {
+		if len(active) > 0 {
 			<div class="reservations-list">
-				for _, res := range wish.ActiveReservations() {
+				for _, res := range active {
 					<div class="reservation-item">
 						{ fmt.Sprintf(i18n.T(lang, "reserved_count"), res.Quantity, i18n.FormatDate(lang, res.ExpiresAt.Time)) }
 					</div>
 				}
 			</div>
 		}
-		// Reserve form - show if unlimited or items available
-		if wish.IsUnlimited() || wish.AvailableQuantity() > 0 {
+		// Reserve form - shown only for what the server will actually accept
+		if reservable > 0 {
 			<form
 				class="reserve-form"
 				hx-post={ fmt.Sprintf("/wishes/%s/reserve?lang=%s", wish.Name, lang) }
 				hx-target={ fmt.Sprintf("#wish-%s", wish.Name) }
 				hx-swap="outerHTML"
 			>
-				// Quantity selector
-				if wish.IsUnlimited() {
-					// For unlimited, show number input
-					<input type="number" name="quantity" value="1" min="1" required/>
-				} else if wish.AvailableQuantity() > 1 {
-					// For limited, show dropdown
-					<select name="quantity" required>
-						for i := int32(1); i <= wish.AvailableQuantity(); i++ {
-							<option value={ fmt.Sprintf("%d", i) }>{ fmt.Sprintf("%d", i) }</option>
-						}
-					</select>
+				// Quantity selector, bounded by whatever the server will accept.
+				// A number input rather than one option per item: the stock has no
+				// upper bound in the schema, so a dropdown is a page-size hazard.
+				if reservable > 1 {
+					<input
+						type="number"
+						name="quantity"
+						value="1"
+						min="1"
+						max={ fmt.Sprintf("%d", reservable) }
+						required
+					/>
 				}
 				<select name="weeks" required>
 					<option value="1">{ fmt.Sprintf("1 %s", i18n.T(lang, "week_one")) }</option>
@@ -118,6 +128,11 @@ templ WishCard(wish *wishlistv1alpha1.Wish, lang string) {
 				</select>
 				<button type="submit">{ i18n.T(lang, "reserve_btn") }</button>
 			</form>
+		} else if atLimit {
+			// Stock may well be left; what ran out is room for another entry.
+			<div class="fully-reserved-badge">
+				{ i18n.T(lang, "err_reservation_limit") }
+			</div>
 		} else {
 			<div class="fully-reserved-badge">
 				{ i18n.T(lang, "err_fully_reserved") }

--- a/internal/templates/wish_card_templ.go
+++ b/internal/templates/wish_card_templ.go
@@ -59,7 +59,11 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		var templ_7745c5c3_Var2 = []any{"wish-card", templ.KV("fully-reserved", wish.IsFullyReserved())}
+		reservable := wish.MaxReservableQuantity()
+		active := wish.ActiveReservations()
+		atLimit := wish.AtReservationLimit()
+		var templ_7745c5c3_Var2 = []any{"wish-card",
+			templ.KV("fully-reserved", wish.IsFullyReserved() || atLimit)}
 		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var2...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -71,7 +75,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("wish-%s", wish.Name))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 33, Col: 44}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 39, Col: 40}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var3)
 		if templ_7745c5c3_Err != nil {
@@ -102,7 +106,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.ResolveAttributeValue(wish.Spec.ImageURL)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 35, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 44, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var5)
 			if templ_7745c5c3_Err != nil {
@@ -115,7 +119,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(wish.Spec.Title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 35, Col: 56}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 44, Col: 56}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var6)
 			if templ_7745c5c3_Err != nil {
@@ -138,7 +142,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 			var templ_7745c5c3_Var7 templ.SafeURL
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(wish.Spec.OfficialURL))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 39, Col: 50}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 48, Col: 50}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -151,7 +155,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(wish.Spec.Title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 39, Col: 86}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 48, Col: 86}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -165,7 +169,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(wish.Spec.Title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 41, Col: 21}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 50, Col: 21}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
@@ -184,7 +188,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(wish.Spec.MSRP)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 45, Col: 38}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 54, Col: 38}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -203,7 +207,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(stars(wish.Spec.Priority))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 48, Col: 49}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 57, Col: 49}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -226,7 +230,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 			var templ_7745c5c3_Var12 string
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(tag)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 52, Col: 27}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 61, Col: 27}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
@@ -245,7 +249,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 			var templ_7745c5c3_Var13 string
 			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(tag)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 55, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 64, Col: 39}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
@@ -268,7 +272,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 			var templ_7745c5c3_Var14 string
 			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(wish.Spec.Description)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 59, Col: 51}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 68, Col: 51}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 			if templ_7745c5c3_Err != nil {
@@ -287,7 +291,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 			var templ_7745c5c3_Var15 string
 			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(lang, "buy_label"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 63, Col: 37}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 72, Col: 37}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 			if templ_7745c5c3_Err != nil {
@@ -305,7 +309,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 				var templ_7745c5c3_Var16 templ.SafeURL
 				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(url))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 65, Col: 33}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 74, Col: 33}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 				if templ_7745c5c3_Err != nil {
@@ -318,7 +322,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 				var templ_7745c5c3_Var17 string
 				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("[%d]", i+1))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 65, Col: 78}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 74, Col: 78}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 				if templ_7745c5c3_Err != nil {
@@ -342,7 +346,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 			var templ_7745c5c3_Var18 string
 			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(lang, "unlimited_available"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 72, Col: 41}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 81, Col: 41}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 			if templ_7745c5c3_Err != nil {
@@ -360,7 +364,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 			var templ_7745c5c3_Var19 string
 			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%s %d/%d", i18n.T(lang, "available_label"), wish.AvailableQuantity(), wish.GetQuantity()))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 76, Col: 108}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 85, Col: 108}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 			if templ_7745c5c3_Err != nil {
@@ -371,12 +375,12 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		if len(wish.ActiveReservations()) > 0 {
+		if len(active) > 0 {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<div class=\"reservations-list\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			for _, res := range wish.ActiveReservations() {
+			for _, res := range active {
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<div class=\"reservation-item\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
@@ -384,7 +388,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 				var templ_7745c5c3_Var20 string
 				templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf(i18n.T(lang, "reserved_count"), res.Quantity, i18n.FormatDate(lang, res.ExpiresAt.Time)))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 84, Col: 108}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 93, Col: 108}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 				if templ_7745c5c3_Err != nil {
@@ -400,7 +404,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		if wish.IsUnlimited() || wish.AvailableQuantity() > 0 {
+		if reservable > 0 {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<form class=\"reserve-form\" hx-post=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -408,7 +412,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 			var templ_7745c5c3_Var21 string
 			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("/wishes/%s/reserve?lang=%s", wish.Name, lang))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 93, Col: 72}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 102, Col: 72}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var21)
 			if templ_7745c5c3_Err != nil {
@@ -421,7 +425,7 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 			var templ_7745c5c3_Var22 string
 			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("#wish-%s", wish.Name))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 94, Col: 50}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 103, Col: 50}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var22)
 			if templ_7745c5c3_Err != nil {
@@ -431,194 +435,184 @@ func WishCard(wish *wishlistv1alpha1.Wish, lang string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if wish.IsUnlimited() {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, " <input type=\"number\" name=\"quantity\" value=\"1\" min=\"1\" required> ")
+			if reservable > 1 {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<input type=\"number\" name=\"quantity\" value=\"1\" min=\"1\" max=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-			} else if wish.AvailableQuantity() > 1 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, " <select name=\"quantity\" required>")
+				var templ_7745c5c3_Var23 string
+				templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", reservable))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 115, Col: 41}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var23)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				for i := int32(1); i <= wish.AvailableQuantity(); i++ {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<option value=\"")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var23 string
-					templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", i))
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 105, Col: 43}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var23)
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "\">")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var24 string
-					templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", i))
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 105, Col: 68}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</option>")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</select> ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\" required> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<select name=\"weeks\" required><option value=\"1\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<select name=\"weeks\" required><option value=\"1\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var24 string
+			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("1 %s", i18n.T(lang, "week_one")))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 120, Col: 70}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</option> <option value=\"2\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var25 string
-			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("1 %s", i18n.T(lang, "week_one")))
+			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("2 %s", i18n.Weeks(lang, 2)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 110, Col: 70}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 121, Col: 65}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</option> <option value=\"2\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</option> <option value=\"3\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var26 string
-			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("2 %s", i18n.Weeks(lang, 2)))
+			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("3 %s", i18n.Weeks(lang, 3)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 111, Col: 65}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 122, Col: 65}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</option> <option value=\"3\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</option> <option value=\"4\" selected>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var27 string
-			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("3 %s", i18n.Weeks(lang, 3)))
+			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("4 %s", i18n.Weeks(lang, 4)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 112, Col: 65}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 123, Col: 74}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</option> <option value=\"4\" selected>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "</option> <option value=\"5\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var28 string
-			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("4 %s", i18n.Weeks(lang, 4)))
+			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("5 %s", i18n.Weeks(lang, 5)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 113, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 124, Col: 65}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</option> <option value=\"5\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</option> <option value=\"6\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var29 string
-			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("5 %s", i18n.Weeks(lang, 5)))
+			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("6 %s", i18n.Weeks(lang, 6)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 114, Col: 65}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 125, Col: 65}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</option> <option value=\"6\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</option> <option value=\"7\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var30 string
-			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("6 %s", i18n.Weeks(lang, 6)))
+			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("7 %s", i18n.Weeks(lang, 7)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 115, Col: 65}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 126, Col: 65}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "</option> <option value=\"7\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</option> <option value=\"8\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var31 string
-			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("7 %s", i18n.Weeks(lang, 7)))
+			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("8 %s", i18n.Weeks(lang, 8)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 116, Col: 65}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 127, Col: 65}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "</option> <option value=\"8\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</option></select> <button type=\"submit\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var32 string
-			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("8 %s", i18n.Weeks(lang, 8)))
+			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(lang, "reserve_btn"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 117, Col: 65}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 129, Col: 55}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "</option></select> <button type=\"submit\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</button></form>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else if atLimit {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, " <div class=\"fully-reserved-badge\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var33 string
-			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(lang, "reserve_btn"))
+			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(lang, "err_reservation_limit"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 119, Col: 55}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 134, Col: 43}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "</button></form>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "<div class=\"fully-reserved-badge\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "<div class=\"fully-reserved-badge\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var34 string
 			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(lang, "err_fully_reserved"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 123, Col: 40}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/wish_card.templ`, Line: 138, Col: 40}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -5,6 +5,7 @@ package web
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"net"
@@ -17,7 +18,10 @@ import (
 	"sync"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	wishlistv1alpha1 "github.com/lexfrei/wish-operator/api/v1alpha1"
@@ -50,6 +54,37 @@ const (
 	ipv6BucketBits = 64
 )
 
+// Terminal reservation outcomes. Each maps to a distinct HTTP response.
+var (
+	errWishNotFound      = errors.New("wish not found")
+	errWishExpired       = errors.New("wish is past its TTL")
+	errGetWish           = errors.New("cannot read wish")
+	errFullyReserved     = errors.New("wish is fully reserved")
+	errReservationLimit  = errors.New("wish holds as many reservations as it can")
+	errInvalidQuantity   = errors.New("quantity is not a positive number")
+	errReserveIncomplete = errors.New("reservation was never attempted")
+)
+
+// quantityExceededError reports that fewer items are left than were requested.
+type quantityExceededError struct {
+	available int32
+}
+
+func (e *quantityExceededError) Error() string {
+	return fmt.Sprintf("requested quantity exceeds the %d available", e.available)
+}
+
+// perRequestLimitError reports that one reservation may not claim this many.
+// Distinct from quantityExceededError: an unlimited wish has nothing to run
+// out of, so telling its visitor how many are "available" would be false.
+type perRequestLimitError struct {
+	limit int32
+}
+
+func (e *perRequestLimitError) Error() string {
+	return fmt.Sprintf("one reservation claims at most %d items", e.limit)
+}
+
 // limiterEntry pairs a per-IP limiter with the last time it was accessed, so
 // idle entries can be evicted instead of growing the map without bound.
 type limiterEntry struct {
@@ -60,6 +95,7 @@ type limiterEntry struct {
 // Server handles HTTP requests for the wishlist web interface.
 type Server struct {
 	client    client.Client
+	reader    client.Reader
 	namespace string
 	rateLimit float64
 	rateBurst int
@@ -67,6 +103,10 @@ type Server struct {
 	// trustedProxyHops is how many proxies append to X-Forwarded-For in front
 	// of this server. Zero means proxy headers are ignored entirely.
 	trustedProxyHops int
+
+	// backoff is the retry schedule for reservation conflicts, a field so a
+	// test can inject one that never runs.
+	backoff wait.Backoff
 
 	// now is the injectable time source, overridden in tests for deterministic
 	// eviction behaviour.
@@ -77,12 +117,15 @@ type Server struct {
 	lastSweep  time.Time
 }
 
-// NewServer creates a new web server. trustedProxyHops declares how many
-// proxies in front of this server append to X-Forwarded-For; use 0 when the
-// server is reachable directly, so that client-supplied proxy headers are
-// ignored.
+// NewServer creates a new web server. The reader must bypass the informer
+// cache: reserving re-reads a wish after a conflict, and a cached read would
+// keep handing back the same stale object the conflict was about.
+// trustedProxyHops declares how many proxies in front of this server append to
+// X-Forwarded-For; use 0 when the server is reachable directly, so that
+// client-supplied proxy headers are ignored.
 func NewServer(
 	c client.Client,
+	reader client.Reader,
 	namespace string,
 	trustedProxyHops int,
 	rateLimit float64,
@@ -90,10 +133,12 @@ func NewServer(
 ) *Server {
 	return &Server{
 		client:           c,
+		reader:           reader,
 		namespace:        namespace,
 		trustedProxyHops: trustedProxyHops,
 		rateLimit:        rateLimit,
 		rateBurst:        rateBurst,
+		backoff:          retry.DefaultRetry,
 		now:              time.Now,
 		limiters:         make(map[string]*limiterEntry),
 	}
@@ -146,7 +191,6 @@ func (s *Server) renderWishPage(w http.ResponseWriter, r *http.Request, fullPage
 	}
 }
 
-//nolint:funlen // Main reserve handler with validation logic
 func (s *Server) handleReserve(w http.ResponseWriter, r *http.Request) {
 	lang := i18n.DetectLanguage(r)
 	name := r.PathValue("name")
@@ -172,61 +216,16 @@ func (s *Server) handleReserve(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse quantity (default to 1)
-	quantity := int32(1)
-	if qStr := r.FormValue("quantity"); qStr != "" {
-		q, err := strconv.ParseInt(qStr, 10, 32)
-		if err != nil || q < 1 {
-			http.Error(w, i18n.T(lang, "err_invalid_quantity"), http.StatusBadRequest)
-
-			return
-		}
-
-		quantity = int32(q)
-	}
-
-	wish := &wishlistv1alpha1.Wish{}
-	if err := s.client.Get(r.Context(), client.ObjectKey{Name: name, Namespace: s.namespace}, wish); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			http.Error(w, i18n.T(lang, "err_not_found"), http.StatusNotFound)
-
-			return
-		}
-
-		http.Error(w, i18n.T(lang, "err_get_wish"), http.StatusInternalServerError)
+	quantity, err := parseQuantity(r.FormValue("quantity"))
+	if err != nil {
+		writeReserveError(w, lang, err)
 
 		return
 	}
 
-	// Check availability using new Reservations model
-	// Skip validation for unlimited wishes (quantity == 0)
-	if !wish.IsUnlimited() {
-		available := wish.AvailableQuantity()
-		if available == 0 {
-			http.Error(w, i18n.T(lang, "err_fully_reserved"), http.StatusConflict)
-
-			return
-		}
-
-		if quantity > available {
-			http.Error(w, fmt.Sprintf(i18n.T(lang, "err_quantity_exceeds"), available), http.StatusBadRequest)
-
-			return
-		}
-	}
-
-	// Create new reservation in new format
-	now := metav1.Now()
-	expires := metav1.NewTime(now.Add(time.Duration(weeks) * 7 * 24 * time.Hour))
-
-	wish.Status.Reservations = append(wish.Status.Reservations, wishlistv1alpha1.Reservation{
-		Quantity:  quantity,
-		CreatedAt: now,
-		ExpiresAt: expires,
-	})
-
-	if err := s.client.Status().Update(r.Context(), wish); err != nil {
-		http.Error(w, i18n.T(lang, "err_reserve_failed"), http.StatusInternalServerError)
+	wish, err := s.reserve(r.Context(), name, weeks, quantity)
+	if err != nil {
+		writeReserveError(w, lang, err)
 
 		return
 	}
@@ -235,6 +234,156 @@ func (s *Server) handleReserve(w http.ResponseWriter, r *http.Request) {
 
 	if err := templates.WishCard(wish, lang).Render(r.Context(), w); err != nil {
 		http.Error(w, i18n.T(lang, "err_render"), http.StatusInternalServerError)
+	}
+}
+
+// reserve appends a reservation to a wish, retrying the whole read-check-write
+// cycle whenever the API server rejects the update with a conflict. Every
+// attempt re-reads the wish through the uncached reader, so availability is
+// checked against the state the reservation is about to be written on top of,
+// including the write that caused the conflict.
+func (s *Server) reserve(
+	ctx context.Context,
+	name string,
+	weeks int,
+	quantity int32,
+) (*wishlistv1alpha1.Wish, error) {
+	var reserved *wishlistv1alpha1.Wish
+
+	err := retry.RetryOnConflict(s.backoff, func() error {
+		wish := &wishlistv1alpha1.Wish{}
+		if err := s.reader.Get(ctx, client.ObjectKey{Name: name, Namespace: s.namespace}, wish); err != nil {
+			if apierrors.IsNotFound(err) {
+				return errWishNotFound
+			}
+
+			return fmt.Errorf("%w: %w", errGetWish, err)
+		}
+
+		// listWishes hides a wish once its TTL runs out; a POST straight at the
+		// name must not be a way around that.
+		if wish.IsExpired() {
+			return errWishExpired
+		}
+
+		if err := checkAvailability(wish, quantity); err != nil {
+			return err
+		}
+
+		now := metav1.Now()
+		expires := metav1.NewTime(now.Add(time.Duration(weeks) * 7 * 24 * time.Hour))
+
+		// Append onto the active ones only: expired entries hold nothing, and
+		// writing them back would re-persist state this code does not believe in.
+		wish.Status.Reservations = append(wish.ActiveReservations(), wishlistv1alpha1.Reservation{
+			Quantity:  quantity,
+			CreatedAt: now,
+			ExpiresAt: expires,
+		})
+
+		if err := s.client.Status().Update(ctx, wish); err != nil {
+			return err
+		}
+
+		reserved = wish
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// A backoff that never runs the closure returns no error and no wish, and
+	// the caller would render a nil card. Nothing produces that today, but the
+	// only thing standing between here and a panic is a constant in client-go.
+	if reserved == nil {
+		return nil, errReserveIncomplete
+	}
+
+	return reserved, nil
+}
+
+// parseQuantity reads the requested quantity, defaulting to a single item.
+func parseQuantity(value string) (int32, error) {
+	if value == "" {
+		return 1, nil
+	}
+
+	quantity, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %w", errInvalidQuantity, err)
+	}
+
+	if quantity < 1 {
+		return 0, errInvalidQuantity
+	}
+
+	return int32(quantity), nil
+}
+
+// checkAvailability reports whether the wish can still take the requested
+// quantity. It answers with the same numbers the card renders, so anything the
+// form offers is something this accepts.
+func checkAvailability(wish *wishlistv1alpha1.Wish, quantity int32) error {
+	if wish.AtReservationLimit() {
+		return errReservationLimit
+	}
+
+	// A wish with declared stock is bounded by what is left of it, and that is
+	// the number worth reporting. The per-request limit only has to speak for
+	// unlimited wishes, where nothing else would.
+	if !wish.IsUnlimited() {
+		available := wish.AvailableQuantity()
+		if available == 0 {
+			return errFullyReserved
+		}
+
+		if quantity > available {
+			return &quantityExceededError{available: available}
+		}
+
+		return nil
+	}
+
+	if quantity > wishlistv1alpha1.MaxQuantityPerRequest {
+		return &perRequestLimitError{limit: wishlistv1alpha1.MaxQuantityPerRequest}
+	}
+
+	return nil
+}
+
+// writeReserveError maps a reservation failure to its HTTP response.
+func writeReserveError(w http.ResponseWriter, lang string, err error) {
+	var (
+		exceeded   *quantityExceededError
+		perRequest *perRequestLimitError
+	)
+
+	switch {
+	// A wish deleted between the read and the write is gone the same way a
+	// wish that was never there is gone.
+	case errors.Is(err, errWishNotFound), errors.Is(err, errWishExpired), apierrors.IsNotFound(err):
+		http.Error(w, i18n.T(lang, "err_not_found"), http.StatusNotFound)
+	case errors.Is(err, errInvalidQuantity):
+		http.Error(w, i18n.T(lang, "err_invalid_quantity"), http.StatusBadRequest)
+	case errors.Is(err, errGetWish):
+		http.Error(w, i18n.T(lang, "err_get_wish"), http.StatusInternalServerError)
+	case errors.Is(err, errFullyReserved):
+		http.Error(w, i18n.T(lang, "err_fully_reserved"), http.StatusConflict)
+	case errors.Is(err, errReservationLimit):
+		http.Error(w, i18n.T(lang, "err_reservation_limit"), http.StatusConflict)
+	case errors.As(err, &exceeded):
+		http.Error(w, fmt.Sprintf(i18n.T(lang, "err_quantity_exceeds"), exceeded.available), http.StatusBadRequest)
+	case errors.As(err, &perRequest):
+		http.Error(w, fmt.Sprintf(i18n.T(lang, "err_quantity_per_request"), perRequest.limit), http.StatusBadRequest)
+	case apierrors.IsConflict(err):
+		// Retries ran out while the wish was under contention. The status code
+		// and Retry-After say so to a machine; the body is the only part a
+		// visitor sees, so it must not read like a broken server.
+		w.Header().Set("Retry-After", "1")
+		http.Error(w, i18n.T(lang, "err_reserve_busy"), http.StatusServiceUnavailable)
+	default:
+		http.Error(w, i18n.T(lang, "err_reserve_failed"), http.StatusInternalServerError)
 	}
 }
 
@@ -250,7 +399,12 @@ func (s *Server) listWishes(ctx context.Context, filterTag string) ([]wishlistv1
 
 	for i := range wishList.Items {
 		wish := &wishList.Items[i]
-		if !wish.Status.Active {
+
+		// The same predicate the reserve path uses. Status.Active says the same
+		// thing, but only once the controller has caught up: a wish that has
+		// never been reconciled would be hidden here while still reservable,
+		// and one whose TTL just passed would be listed while already refused.
+		if wish.IsExpired() {
 			continue
 		}
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -5,24 +5,34 @@ package web
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	wishlistv1alpha1 "github.com/lexfrei/wish-operator/api/v1alpha1"
+	"github.com/lexfrei/wish-operator/internal/i18n"
 
 	"golang.org/x/time/rate"
 )
@@ -48,7 +58,30 @@ const (
 	testDirectRemoteAddr   = testDirectIP + ":5000"
 	testUnsplittableAddr   = "not-a-host-port"
 	testExpiredResName     = "expired-reservation-wish"
+	testConflictName       = "conflict-wish"
+	testRaceName           = "race-wish"
+	testExhaustedName      = "exhausted-wish"
+	testStaleName          = "stale-wish"
+	testExpiredName        = "expired-wish"
+	testReadErrorName      = "read-error-wish"
+	testQuantityName       = "quantity-wish"
+	testNotANumber         = "abc"
+	testTTLName            = "ttl-wish"
+	testUpdateFailName     = "update-fail-wish"
+	testDeletedName        = "deleted-wish"
+	testCapName            = "cap-wish"
+	testCapQuantityName    = "cap-quantity-wish"
+	testLargeStockName     = "large-stock-wish"
+	testCountCapName       = "count-cap-wish"
+	testOfferName          = "offer-wish"
+	testNeverReconciled    = "never-reconciled-wish"
+	testHugeStockName      = "huge-stock-wish"
+	testNoStepsName        = "no-steps-wish"
+	testTagFilter          = "electronics"
 )
+
+// errObjectModified is the cause carried by the simulated conflict responses.
+var errObjectModified = errors.New("the object has been modified")
 
 // newTestServer builds a server with the shipped default hop count, so tests
 // that do not care about proxies exercise the configuration the chart produces.
@@ -56,10 +89,42 @@ const (
 func newTestServer(t *testing.T, wishes ...*wishlistv1alpha1.Wish) *Server {
 	t.Helper()
 
-	return newTestServerWithHops(t, 0, wishes...)
+	return newTestServerFrom(t, 0, interceptor.Funcs{}, wishes...)
 }
 
+// newTestServerWithHops sets the trusted-proxy hop count for proxy-header tests.
 func newTestServerWithHops(t *testing.T, hops int, wishes ...*wishlistv1alpha1.Wish) *Server {
+	t.Helper()
+
+	return newTestServerFrom(t, hops, interceptor.Funcs{}, wishes...)
+}
+
+// newTestServerWithInterceptor installs fake-client interceptors for the
+// conflict and error-path tests.
+func newTestServerWithInterceptor(
+	t *testing.T,
+	funcs interceptor.Funcs,
+	wishes ...*wishlistv1alpha1.Wish,
+) *Server {
+	t.Helper()
+
+	return newTestServerFrom(t, 0, funcs, wishes...)
+}
+
+func newTestServerFrom(
+	t *testing.T,
+	hops int,
+	funcs interceptor.Funcs,
+	wishes ...*wishlistv1alpha1.Wish,
+) *Server {
+	t.Helper()
+
+	fakeClient := newFakeClient(t, funcs, wishes...)
+
+	return NewServer(fakeClient, fakeClient, testNamespace, hops, 30, 10)
+}
+
+func newFakeClient(t *testing.T, funcs interceptor.Funcs, wishes ...*wishlistv1alpha1.Wish) client.WithWatch {
 	t.Helper()
 
 	scheme := runtime.NewScheme()
@@ -71,13 +136,80 @@ func newTestServerWithHops(t *testing.T, hops int, wishes ...*wishlistv1alpha1.W
 		objs[i] = w
 	}
 
-	fakeClient := fake.NewClientBuilder().
+	return fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(objs...).
 		WithStatusSubresource(objs...).
+		WithInterceptorFuncs(funcs).
 		Build()
+}
 
-	return NewServer(fakeClient, testNamespace, hops, 30, 10)
+// wishGroupResource identifies the CRD in synthetic API errors.
+func wishGroupResource() schema.GroupResource {
+	return schema.GroupResource{Group: "wishlist.k8s.lex.la", Resource: "wishes"}
+}
+
+// conflictError builds an apierrors Conflict for a wish, the retryable outcome
+// that a reservation must transparently recover from.
+func conflictError(name string) error {
+	return apierrors.NewConflict(wishGroupResource(), name, errObjectModified)
+}
+
+// reservableWish builds an active wish with the given stock, ready to reserve.
+func reservableWish(name string, quantity int32) *wishlistv1alpha1.Wish {
+	return &wishlistv1alpha1.Wish{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: wishlistv1alpha1.WishSpec{
+			Title:    testTitleGift,
+			Quantity: quantity,
+		},
+		Status: wishlistv1alpha1.WishStatus{
+			Active: true,
+		},
+	}
+}
+
+// reserveRequest builds a reservation POST for the named wish.
+func reserveRequest(name, weeks, quantity string) *http.Request {
+	form := url.Values{}
+	form.Set("weeks", weeks)
+	form.Set("quantity", quantity)
+
+	req := httptest.NewRequest(http.MethodPost, "/wishes/"+name+"/reserve", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return req
+}
+
+// cardHTML returns just the named wish's card out of a rendered page. It cuts
+// at card ids rather than at closing tags, so it survives changes to the card's
+// internal markup and fails loudly if the card is missing altogether.
+func cardHTML(t *testing.T, page, name string) string {
+	t.Helper()
+
+	start := strings.Index(page, `id="wish-`+name+`"`)
+	require.GreaterOrEqual(t, start, 0, "no card for wish %q on the page", name)
+
+	card := page[start:]
+	if next := strings.Index(card[1:], `id="wish-`); next >= 0 {
+		card = card[:next+1]
+	}
+
+	return card
+}
+
+// getWish reads a wish back from the server's client.
+func getWish(t *testing.T, srv *Server, name string) *wishlistv1alpha1.Wish {
+	t.Helper()
+
+	wish := &wishlistv1alpha1.Wish{}
+	err := srv.client.Get(context.Background(), client.ObjectKey{Name: name, Namespace: testNamespace}, wish)
+	require.NoError(t, err)
+
+	return wish
 }
 
 func TestServer_HandleIndex(t *testing.T) {
@@ -484,6 +616,10 @@ func TestServer_HandleReserve_QuantityExceedsAvailable(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// The message has to name how many are actually left.
+	assert.Contains(t, rec.Body.String(),
+		fmt.Sprintf(i18n.T(i18n.DefaultLang, "err_quantity_exceeds"), 2))
 }
 
 func TestServer_HandleReserve_InvalidWeeks(t *testing.T) {
@@ -497,7 +633,7 @@ func TestServer_HandleReserve_InvalidWeeks(t *testing.T) {
 		{"zero weeks", "0", http.StatusBadRequest},
 		{"negative weeks", "-1", http.StatusBadRequest},
 		{"too many weeks", "9", http.StatusBadRequest},
-		{"non-numeric", "abc", http.StatusBadRequest},
+		{"non-numeric", testNotANumber, http.StatusBadRequest},
 	}
 
 	for _, tt := range tests {
@@ -1329,4 +1465,661 @@ func TestServer_LimiterCapKeepsTheServedEntry(t *testing.T) {
 
 		assert.LessOrEqual(t, len(srv.limiters), limiterMaxEntries)
 	})
+}
+
+func TestServer_HandleReserve_RetriesOnConflict(t *testing.T) {
+	t.Parallel()
+
+	var updates atomic.Int32
+
+	funcs := interceptor.Funcs{
+		SubResourceUpdate: func(
+			ctx context.Context,
+			cl client.Client,
+			_ string,
+			obj client.Object,
+			opts ...client.SubResourceUpdateOption,
+		) error {
+			if updates.Add(1) == 1 {
+				return conflictError(testConflictName)
+			}
+
+			return cl.Status().Update(ctx, obj, opts...)
+		},
+	}
+
+	srv := newTestServerWithInterceptor(t, funcs, reservableWish(testConflictName, 3))
+	rec := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(rec, reserveRequest(testConflictName, "4", "2"))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, int32(2), updates.Load(), "the update should be retried exactly once")
+
+	// The retry must not duplicate the reservation.
+	updated := getWish(t, srv, testConflictName)
+	require.Len(t, updated.Status.Reservations, 1)
+	assert.Equal(t, int32(2), updated.Status.Reservations[0].Quantity)
+}
+
+func TestServer_HandleReserve_ConflictThenFullyReserved(t *testing.T) {
+	t.Parallel()
+
+	var updates atomic.Int32
+
+	// The first update loses the race to a visitor who takes the whole stock,
+	// so the retry has to re-validate against the refreshed wish.
+	funcs := interceptor.Funcs{
+		SubResourceUpdate: func(
+			ctx context.Context,
+			cl client.Client,
+			_ string,
+			obj client.Object,
+			opts ...client.SubResourceUpdateOption,
+		) error {
+			if updates.Add(1) > 1 {
+				return cl.Status().Update(ctx, obj, opts...)
+			}
+
+			current := &wishlistv1alpha1.Wish{}
+			if err := cl.Get(ctx,
+				client.ObjectKey{Name: testRaceName, Namespace: testNamespace},
+				current); err != nil {
+				return err
+			}
+
+			now := metav1.Now()
+			current.Status.Reservations = append(current.Status.Reservations, wishlistv1alpha1.Reservation{
+				Quantity:  2,
+				CreatedAt: now,
+				ExpiresAt: metav1.NewTime(now.Add(7 * 24 * time.Hour)),
+			})
+
+			if err := cl.Status().Update(ctx, current); err != nil {
+				return err
+			}
+
+			return conflictError(testRaceName)
+		},
+	}
+
+	srv := newTestServerWithInterceptor(t, funcs, reservableWish(testRaceName, 2))
+	rec := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(rec, reserveRequest(testRaceName, "4", "2"))
+
+	assert.Equal(t, http.StatusConflict, rec.Code)
+	assert.Equal(t, int32(1), updates.Load(), "the retry must abort before updating again")
+
+	// Only the competing reservation survives.
+	updated := getWish(t, srv, testRaceName)
+	require.Len(t, updated.Status.Reservations, 1)
+	assert.Equal(t, int32(2), updated.Status.Reservations[0].Quantity)
+}
+
+func TestServer_HandleReserve_ConflictRetriesExhausted(t *testing.T) {
+	t.Parallel()
+
+	var updates atomic.Int32
+
+	funcs := interceptor.Funcs{
+		SubResourceUpdate: func(
+			_ context.Context,
+			_ client.Client,
+			_ string,
+			_ client.Object,
+			_ ...client.SubResourceUpdateOption,
+		) error {
+			updates.Add(1)
+
+			return conflictError(testExhaustedName)
+		},
+	}
+
+	srv := newTestServerWithInterceptor(t, funcs, reservableWish(testExhaustedName, 3))
+	rec := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(rec, reserveRequest(testExhaustedName, "4", "1"))
+
+	// Contention is not a broken server, so the visitor is told to come back.
+	// The status code and the header say that to a machine; the body is the
+	// only part a person reads, so it must not be the failure message.
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, "1", rec.Header().Get("Retry-After"))
+	assert.Contains(t, rec.Body.String(), i18n.T(i18n.DefaultLang, "err_reserve_busy"))
+	assert.NotContains(t, rec.Body.String(), i18n.T(i18n.DefaultLang, "err_reserve_failed"))
+	assert.Greater(t, updates.Load(), int32(1), "the update should be retried before giving up")
+	assert.Empty(t, getWish(t, srv, testExhaustedName).Status.Reservations)
+}
+
+func TestServer_HandleReserve_ReadsThroughUncachedReader(t *testing.T) {
+	t.Parallel()
+
+	now := metav1.Now()
+
+	// What the informer cache still holds: the wish is fully reserved.
+	stale := reservableWish(testStaleName, 1)
+	stale.Status.Reservations = []wishlistv1alpha1.Reservation{
+		{
+			Quantity:  1,
+			CreatedAt: now,
+			ExpiresAt: metav1.NewTime(now.Add(7 * 24 * time.Hour)),
+		},
+	}
+
+	// What the API server holds: the reservation is gone, the item is free.
+	fresh := reservableWish(testStaleName, 1)
+
+	cached := newFakeClient(t, interceptor.Funcs{}, stale)
+	live := newFakeClient(t, interceptor.Funcs{}, fresh)
+	srv := NewServer(cached, live, testNamespace, 0, 30, 10)
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, reserveRequest(testStaleName, "4", "1"))
+
+	// A cached read would answer 409 on the stale copy.
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestServer_HandleReserve_DoesNotRePersistExpiredReservations(t *testing.T) {
+	t.Parallel()
+
+	past := metav1.NewTime(time.Now().Add(-time.Hour))
+	future := metav1.NewTime(time.Now().Add(time.Hour))
+
+	// One reservation has expired, one is live, and the controller has pruned
+	// neither yet. Whether the expired one still blocks is a question for the
+	// availability math; this test is only about what gets written back.
+	wish := reservableWish(testExpiredName, 3)
+	wish.Status.Reservations = []wishlistv1alpha1.Reservation{
+		{
+			Quantity:  1,
+			CreatedAt: metav1.NewTime(past.Add(-time.Hour)),
+			ExpiresAt: past,
+		},
+		{
+			Quantity:  1,
+			CreatedAt: metav1.NewTime(past.Add(-time.Hour)),
+			ExpiresAt: future,
+		},
+	}
+
+	srv := newTestServer(t, wish)
+	rec := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(rec, reserveRequest(testExpiredName, "4", "1"))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Writing the new reservation must not re-persist the expired one.
+	stored := getWish(t, srv, testExpiredName).Status.Reservations
+	require.Len(t, stored, 2)
+
+	for _, res := range stored {
+		assert.True(t, res.ExpiresAt.After(time.Now()), "expired reservation was written back")
+	}
+}
+
+func TestServer_HandleReserve_ReservationCountCapped(t *testing.T) {
+	t.Parallel()
+
+	now := metav1.Now()
+	expires := metav1.NewTime(now.Add(7 * 24 * time.Hour))
+
+	// An unlimited wish has no availability ceiling of its own, so without a cap
+	// an anonymous POST loop grows this object until the API server refuses it.
+	wish := reservableWish(testCapName, 0)
+	wish.Status.Reservations = make([]wishlistv1alpha1.Reservation, wishlistv1alpha1.MaxReservations)
+
+	for i := range wish.Status.Reservations {
+		wish.Status.Reservations[i] = wishlistv1alpha1.Reservation{
+			Quantity:  1,
+			CreatedAt: now,
+			ExpiresAt: expires,
+		}
+	}
+
+	srv := newTestServer(t, wish)
+	rec := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(rec, reserveRequest(testCapName, "4", "1"))
+
+	assert.Equal(t, http.StatusConflict, rec.Code)
+	assert.Len(t, getWish(t, srv, testCapName).Status.Reservations, wishlistv1alpha1.MaxReservations)
+}
+
+func TestServer_HandleReserve_LargeStockNotCapped(t *testing.T) {
+	t.Parallel()
+
+	// A wish with declared stock is bounded by that stock, not by the limit that
+	// exists for unlimited ones: asking for 200 of 500 has to work. What the
+	// card offers for such a wish is pinned separately, by the page-size test.
+	const (
+		stock  = 500
+		wanted = 200
+	)
+
+	srv := newTestServer(t, reservableWish(testLargeStockName, stock))
+	rec := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(rec, reserveRequest(testLargeStockName, "4", strconv.Itoa(wanted)))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	stored := getWish(t, srv, testLargeStockName).Status.Reservations
+	require.Len(t, stored, 1)
+	assert.Equal(t, int32(wanted), stored[0].Quantity)
+}
+
+func TestServer_HandleReserve_CountCapWithStockLeft(t *testing.T) {
+	t.Parallel()
+
+	now := metav1.Now()
+	expires := metav1.NewTime(now.Add(7 * 24 * time.Hour))
+
+	// Stock left, but no room for another entry. That is a different refusal
+	// from "everything is taken", and the card must not offer a form for it.
+	wish := reservableWish(testCountCapName, 1000)
+	wish.Status.Reservations = make([]wishlistv1alpha1.Reservation, wishlistv1alpha1.MaxReservations)
+
+	for i := range wish.Status.Reservations {
+		wish.Status.Reservations[i] = wishlistv1alpha1.Reservation{
+			Quantity:  1,
+			CreatedAt: now,
+			ExpiresAt: expires,
+		}
+	}
+
+	srv := newTestServer(t, wish)
+	rec := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(rec, reserveRequest(testCountCapName, "4", "1"))
+
+	assert.Equal(t, http.StatusConflict, rec.Code)
+	assert.Contains(t, rec.Body.String(), i18n.T(i18n.DefaultLang, "err_reservation_limit"))
+	assert.NotContains(t, rec.Body.String(), i18n.T(i18n.DefaultLang, "err_fully_reserved"))
+
+	// The page must agree: no reserve form for a wish that cannot take one, and
+	// it must not claim the stock is gone when 900 of 1000 are still free.
+	page := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(page, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusOK, page.Code)
+	// Scoped to this wish's card: the page may grow other forms later.
+	assert.NotContains(t, cardHTML(t, page.Body.String(), testCountCapName), "<form")
+	assert.Contains(t, page.Body.String(), i18n.T(i18n.DefaultLang, "err_reservation_limit"))
+	assert.NotContains(t, page.Body.String(), i18n.T(i18n.DefaultLang, "err_fully_reserved"))
+}
+
+func TestServer_HandleIndex_OffersOnlyWhatTheServerAccepts(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t, reservableWish(testOfferName, 0))
+	rec := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// An unlimited wish gets a number input, and it must stop where the server
+	// stops rather than inviting a value that comes back as 400.
+	assert.Contains(t, rec.Body.String(),
+		fmt.Sprintf("max=\"%d\"", wishlistv1alpha1.MaxQuantityPerRequest))
+}
+
+func TestServer_HandleIndex_LargeStockStaysSmall(t *testing.T) {
+	t.Parallel()
+
+	// spec.quantity has no upper bound in the schema, so one <option> per item
+	// turns a typo into a multi-megabyte page served to anonymous visitors.
+	const stock = 20000
+
+	srv := newTestServer(t, reservableWish(testHugeStockName, stock))
+	rec := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	body := rec.Body.String()
+
+	// Only the reservation-length options may appear; the item list is gone.
+	assert.LessOrEqual(t, strings.Count(body, "<option"), maxWeeks)
+	assert.Contains(t, body, fmt.Sprintf("max=\"%d\"", stock))
+}
+
+func TestCardHTML_IsolatesOneCard(t *testing.T) {
+	t.Parallel()
+
+	// Two cards on one page, and the form-less one must sort first, so that
+	// cutting at the next card is what excludes the other card's form. If it
+	// sorted last the helper could return the whole tail and still pass.
+	// listWishes sorts by priority descending, then title ascending.
+	full := reservableWish(testOfferName, 3)
+	full.Spec.Title = "B gift with a form"
+
+	empty := reservableWish(testCountCapName, 1)
+	empty.Spec.Title = "A gift without a form"
+	empty.Status.Reservations = []wishlistv1alpha1.Reservation{
+		{
+			Quantity:  1,
+			CreatedAt: metav1.Now(),
+			ExpiresAt: metav1.NewTime(time.Now().Add(time.Hour)),
+		},
+	}
+
+	srv := newTestServer(t, full, empty)
+	rec := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// The reservable wish has a form, the fully reserved one does not, and
+	// neither card may carry the other's markup.
+	assert.Contains(t, cardHTML(t, rec.Body.String(), testOfferName), "<form")
+	assert.NotContains(t, cardHTML(t, rec.Body.String(), testCountCapName), "<form")
+}
+
+func TestServer_HandleIndex_QuantityInputIsStyled(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t, reservableWish(testOfferName, 5))
+	rec := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	body := rec.Body.String()
+	require.Contains(t, body, `type="number"`)
+
+	// The quantity control used to be a select, which the card's rule covers.
+	// As an input it needs the same rule, or it renders unstyled: a light box
+	// with dark text inside a dark card, at a different height from the weeks
+	// select beside it.
+	styled := regexp.MustCompile(`\.wish-card select,[^{]*\.wish-card input[^{]*\{`)
+	assert.Regexp(t, styled, body)
+}
+
+func TestServer_HandleIndex_ShowsErrorResponses(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t, reservableWish(testOfferName, 3))
+	rec := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	// htmx does not swap the body of a non-2xx response, so without somewhere to
+	// put it every refusal the server explains is discarded by the browser.
+	body := rec.Body.String()
+	assert.Contains(t, body, `id="error-banner"`)
+	assert.Contains(t, body, "htmx:responseError")
+
+	// A dropped or timed-out request produces no response at all, which is the
+	// same dead-button experience the banner exists to remove.
+	assert.Contains(t, body, "htmx:sendError")
+	assert.Contains(t, body, "htmx:timeout")
+
+	// Those carry no body, so the message they show has to come from here.
+	assert.Contains(t, body, i18n.T(i18n.DefaultLang, "err_no_response"))
+
+	// And a 409 means the card is offering a form that cannot succeed any
+	// more, so the page has to be told where to get the current state.
+	assert.Contains(t, body, `data-refresh="/wishes?lang=`+i18n.DefaultLang+`"`)
+	assert.Contains(t, body, "htmx.ajax('GET'")
+
+	// The refresh the 409 issues is itself a success, so the banner-clearing
+	// handler must skip it by matching its path, or the message it just showed
+	// vanishes at once. Pinned at the markup level; there is no JS test rig.
+	assert.Contains(t, body, "el.dataset.refresh")
+	assert.Contains(t, body, "requestConfig")
+}
+
+func TestServer_HandleIndex_RefreshKeepsTheTagFilter(t *testing.T) {
+	t.Parallel()
+
+	wish := reservableWish(testOfferName, 3)
+	wish.Spec.Tags = []string{testTagFilter}
+
+	srv := newTestServer(t, wish)
+
+	// Filtered: the 409 refresh must reload the same filtered list, not reset
+	// the page to "All". Asserted on the data-refresh attribute rather than the
+	// page, since the filter bar renders tag= links for every tag regardless.
+	filtered := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(filtered, httptest.NewRequest(http.MethodGet, "/?tag="+testTagFilter, nil))
+	assert.Equal(t, http.StatusOK, filtered.Code)
+	assert.Contains(t, filtered.Body.String(),
+		`data-refresh="/wishes?lang=`+i18n.DefaultLang+`&amp;tag=`+testTagFilter+`"`)
+
+	// Unfiltered: no tag to carry, so the refresh URL has none.
+	all := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(all, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusOK, all.Code)
+	assert.Contains(t, all.Body.String(), `data-refresh="/wishes?lang=`+i18n.DefaultLang+`"`)
+	assert.NotContains(t, all.Body.String(), `data-refresh="/wishes?lang=`+i18n.DefaultLang+`&amp;tag=`)
+}
+
+func TestServer_HandleReserve_QuantityCapped(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		quantity string
+		expected int
+	}{
+		{"at the cap", strconv.Itoa(wishlistv1alpha1.MaxQuantityPerRequest), http.StatusOK},
+		{"above the cap", strconv.Itoa(wishlistv1alpha1.MaxQuantityPerRequest + 1), http.StatusBadRequest},
+		{"int32 ceiling", strconv.Itoa(math.MaxInt32), http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Unlimited: nothing but the cap stands between the request and the
+			// number it asked for.
+			srv := newTestServer(t, reservableWish(testCapQuantityName, 0))
+			rec := httptest.NewRecorder()
+
+			srv.Handler().ServeHTTP(rec, reserveRequest(testCapQuantityName, "4", tt.quantity))
+
+			assert.Equal(t, tt.expected, rec.Code)
+
+			if tt.expected != http.StatusBadRequest {
+				return
+			}
+
+			// The card for this wish says "Available: unlimited", so the refusal
+			// must talk about the per-reservation limit rather than claim only a
+			// hundred exist.
+			assert.Contains(t, rec.Body.String(),
+				fmt.Sprintf(i18n.T(i18n.DefaultLang, "err_quantity_per_request"),
+					wishlistv1alpha1.MaxQuantityPerRequest))
+			assert.NotContains(t, rec.Body.String(),
+				fmt.Sprintf(i18n.T(i18n.DefaultLang, "err_quantity_exceeds"),
+					wishlistv1alpha1.MaxQuantityPerRequest))
+		})
+	}
+}
+
+func TestServer_Reserve_BackoffThatNeverRuns(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t, reservableWish(testNoStepsName, 3))
+
+	// RetryOnConflict with no steps never calls the closure and reports no
+	// error, which would hand the handler a nil wish to render.
+	srv.backoff = wait.Backoff{}
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, reserveRequest(testNoStepsName, "4", "1"))
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Empty(t, getWish(t, srv, testNoStepsName).Status.Reservations)
+}
+
+func TestServer_ListingAndReserveAgreeOnTTL(t *testing.T) {
+	t.Parallel()
+
+	// Status.Active is written by the controller, so it lags reality in both
+	// directions. The page and the reserve path must not disagree while it
+	// catches up: what is listed is reservable, what is refused is not listed.
+	tests := []struct {
+		name   string
+		age    time.Duration
+		ttl    time.Duration
+		active bool
+		listed bool
+	}{
+		{"never reconciled", time.Minute, time.Hour, false, true},
+		{"expired but not yet reconciled", 2 * time.Hour, time.Hour, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			wish := reservableWish(testNeverReconciled, 3)
+			wish.CreationTimestamp = metav1.NewTime(time.Now().Add(-tt.age))
+			wish.Spec.TTL = &metav1.Duration{Duration: tt.ttl}
+			wish.Status.Active = tt.active
+
+			srv := newTestServer(t, wish)
+
+			page := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(page, httptest.NewRequest(http.MethodGet, "/", nil))
+
+			listed := strings.Contains(page.Body.String(), testNeverReconciled)
+			assert.Equal(t, tt.listed, listed, "listing")
+
+			rec := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rec, reserveRequest(testNeverReconciled, "4", "1"))
+
+			// One expectation, one agreement check: reservability is not an
+			// independent axis, it is whatever the listing says.
+			assert.Equal(t, listed, rec.Code == http.StatusOK, "listing and reserve must agree")
+		})
+	}
+}
+
+func TestServer_HandleReserve_ExpiredWish(t *testing.T) {
+	t.Parallel()
+
+	// The TTL ran out an hour ago, so listWishes no longer shows this wish.
+	// A POST straight at its name must not get a reservation either.
+	wish := reservableWish(testTTLName, 3)
+	wish.CreationTimestamp = metav1.NewTime(time.Now().Add(-2 * time.Hour))
+	wish.Spec.TTL = &metav1.Duration{Duration: time.Hour}
+
+	srv := newTestServer(t, wish)
+	rec := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(rec, reserveRequest(testTTLName, "4", "1"))
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Empty(t, getWish(t, srv, testTTLName).Status.Reservations)
+}
+
+func TestServer_HandleReserve_UpdateFails(t *testing.T) {
+	t.Parallel()
+
+	funcs := interceptor.Funcs{
+		SubResourceUpdate: func(
+			_ context.Context,
+			_ client.Client,
+			_ string,
+			_ client.Object,
+			_ ...client.SubResourceUpdateOption,
+		) error {
+			return apierrors.NewInternalError(errObjectModified)
+		},
+	}
+
+	srv := newTestServerWithInterceptor(t, funcs, reservableWish(testUpdateFailName, 3))
+	rec := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(rec, reserveRequest(testUpdateFailName, "4", "1"))
+
+	// A write failure that is not a conflict is a server error, not a retry hint.
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Empty(t, rec.Header().Get("Retry-After"))
+	assert.Contains(t, rec.Body.String(), i18n.T(i18n.DefaultLang, "err_reserve_failed"))
+}
+
+func TestServer_HandleReserve_DeletedDuringUpdate(t *testing.T) {
+	t.Parallel()
+
+	funcs := interceptor.Funcs{
+		SubResourceUpdate: func(
+			_ context.Context,
+			_ client.Client,
+			_ string,
+			_ client.Object,
+			_ ...client.SubResourceUpdateOption,
+		) error {
+			return apierrors.NewNotFound(wishGroupResource(), testDeletedName)
+		},
+	}
+
+	srv := newTestServerWithInterceptor(t, funcs, reservableWish(testDeletedName, 3))
+	rec := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(rec, reserveRequest(testDeletedName, "4", "1"))
+
+	// The wish went away between the read and the write.
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestServer_HandleReserve_ReadError(t *testing.T) {
+	t.Parallel()
+
+	funcs := interceptor.Funcs{
+		Get: func(
+			_ context.Context,
+			_ client.WithWatch,
+			_ client.ObjectKey,
+			_ client.Object,
+			_ ...client.GetOption,
+		) error {
+			return apierrors.NewInternalError(errObjectModified)
+		},
+	}
+
+	srv := newTestServerWithInterceptor(t, funcs, reservableWish(testReadErrorName, 3))
+	rec := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(rec, reserveRequest(testReadErrorName, "4", "1"))
+
+	// A read failure that is not "gone" must not look like a missing wish,
+	// and it must not be reported as a failed write either.
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), i18n.T(i18n.DefaultLang, "err_get_wish"))
+}
+
+func TestServer_HandleReserve_Quantity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		quantity string
+		expected int
+	}{
+		{"empty defaults to one", "", http.StatusOK},
+		{"letters", testNotANumber, http.StatusBadRequest},
+		{"zero", "0", http.StatusBadRequest},
+		{"negative", "-1", http.StatusBadRequest},
+		{"above int32", "99999999999", http.StatusBadRequest},
+		{"fractional", "1.5", http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := newTestServer(t, reservableWish(testQuantityName, 0))
+			rec := httptest.NewRecorder()
+
+			srv.Handler().ServeHTTP(rec, reserveRequest(testQuantityName, "4", tt.quantity))
+
+			assert.Equal(t, tt.expected, rec.Code)
+		})
+	}
 }


### PR DESCRIPTION
Reserving a wish read the object, checked availability, appended a reservation and wrote the status back. If anything touched the wish in between, a second visitor reserving the same item or the controller sweeping expired reservations, the update came back with a conflict and the visitor got a 500. That cycle now runs inside RetryOnConflict, and the re-read goes through the uncached API reader. Structured reads from the manager's client are served from the informer cache, which is updated asynchronously, so a cached re-read hands back the same stale object the conflict was about and the retry never converges. Terminal outcomes are mapped in one place: 404 for a wish that is missing, past its TTL, or deleted between the read and the write; 409 once it is fully reserved or at its reservation-count limit; 400 for a quantity that is not positive or larger than what is left; 503 with `Retry-After` for exhausted retries, since contention is not a broken server.

Reserving is anonymous, and an unlimited wish had no ceiling on either axis. A request loop could grow `status.reservations` past what the API server accepts, after which nothing can update the wish again, including the controller pass that prunes expired entries. Two limits now bound it, and they live in `api/v1alpha1` so the card and the server honour the same numbers through `MaxReservableQuantity`, so the form cannot offer a value the server will refuse. A wish holds at most 100 live reservations, and a single reservation on an unlimited wish claims at most 100 items. A wish with declared stock stays bounded by that stock however large it is. Running out of room for another entry is a different refusal from running out of items, so it carries its own message.

htmx does not swap the body of a non-2xx response, so every refusal the server explains is surfaced through an error banner. It also covers dropped and timed-out requests, which arrive with no body at all, the exact case where saying nothing looks like a dead button. A 409 means the card is offering a form that can no longer succeed, so it refreshes the list from the server, carrying the active tag so a filtered view is not reset to All, and keyed so the refresh's own success does not clear the message that triggered it. A non-`text/plain` error body, such as an HTML page from a gateway 502, falls back to the generic message rather than rendering markup as text.

Tests cover the conflict paths through the fake client interceptor (conflict then success, a competing visitor taking the last item so the retry refuses rather than overbooking, and permanent conflict), the uncached-reader read path, both caps at the boundary and one below, the TTL guard, quantity parsing, a non-404 read failure, a delete mid-write, a zero-step backoff, and the banner markup for the dropped-request, tag-preservation and refresh-does-not-clear behaviours. The CRD description and both manifest copies are pinned against the constants, and the README section against the same numbers.
