### PR TITLE
ci(release): pin Helm, helm-unittest and yq in the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,8 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v5
         with:
-          version: 'latest'
+          # renovate: datasource=github-releases depName=helm/helm
+          version: v4.2.3
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -39,7 +40,8 @@ jobs:
 
       - name: Install tools
         run: |
-          helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
+          # renovate: datasource=github-releases depName=helm-unittest/helm-unittest
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.1.2 --verify=false
           pip install check-jsonschema
 
       - name: Run Helm Lint
@@ -276,7 +278,8 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v5
         with:
-          version: latest
+          # renovate: datasource=github-releases depName=helm/helm
+          version: v4.2.3
 
       - name: Install oras
         uses: oras-project/setup-oras@v2
@@ -286,6 +289,7 @@ jobs:
 
       - name: Install yq
         run: |
+          # renovate: datasource=github-releases depName=mikefarah/yq
           YQ_VERSION="4.44.3"
           wget --quiet https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 --output-document yq
           chmod +x yq


### PR DESCRIPTION
The release workflow runs from the tag, so whatever it installs at build time is what ships. It ran Helm at `latest`, installed helm-unittest from its default branch, and hardcoded a yq version with no update path, so a tag build could pull different tooling than the PR checks ran against with no warning, and a `latest` Helm that jumps a major would break the `--verify` flag the plugin install already depends on.

This pins all three to the versions the PR workflow already uses (Helm v4.2.3, helm-unittest 1.1.2) and gives yq a `# renovate:` annotation so it is tracked like the rest. Each annotation sits on the line directly above the version, and I confirmed all four are picked up by the shared preset's custom manager by running its regex against the file rather than reading it: helm/helm twice, helm-unittest, mikefarah/yq. This is release prep and should land before the v0.5.0 tag is cut.
