### PR TITLE
fix(ci): pin cosign-installer to v4.1.2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -213,7 +213,7 @@ jobs:
           docker buildx imagetools inspect ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Sign container images
         env:
@@ -285,7 +285,7 @@ jobs:
         uses: oras-project/setup-oras@v2
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Install yq
         run: |


### PR DESCRIPTION
sigstore/cosign-installer stopped publishing a floating `v4` major tag (only specific `v4.x` releases exist), so `uses: ...@v4` fails to resolve at release time with "unable to find version v4". The Publish Helm Chart and Merge Manifests jobs both hit this on the v0.5.0 tag and never ran. This pins to the current `v4.1.2`. The change is release.yaml-only and does not affect the code checks.